### PR TITLE
Implement discrete icon paging

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -1,11 +1,12 @@
 package com.retrobreeze.ribbonlauncher
 
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PageSize
+import androidx.compose.foundation.pager.PagerDefaults
+import androidx.compose.foundation.pager.PagerSnapDistance
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,48 +24,31 @@ fun GameCarousel(
     onLaunch: (GameEntry) -> Unit
 ) {
     val context = LocalContext.current
-    val listState = rememberLazyListState()
+    val pagerState = rememberPagerState(initialPage = 0) { games.size }
     val itemSpacing = 32.dp
     val itemSize = 150.dp
     val selectedScale = 1.25f
 
-    // Detect center item
-    val centerItemIndex by remember {
-        derivedStateOf {
-            val layoutInfo = listState.layoutInfo
-            val viewportCenter = (layoutInfo.viewportEndOffset + layoutInfo.viewportStartOffset) / 2
-            layoutInfo.visibleItemsInfo.minByOrNull { item ->
-                abs((item.offset + item.size / 2) - viewportCenter)
-            }?.index ?: 0
-        }
-    }
-
-    LaunchedEffect(listState.isScrollInProgress, centerItemIndex) {
-        if (!listState.isScrollInProgress) {
-            val layoutInfo = listState.layoutInfo
-            val itemInfo = layoutInfo.visibleItemsInfo
-                .firstOrNull { it.index == centerItemIndex }
-                ?: return@LaunchedEffect
-            val viewportCenter = (layoutInfo.viewportEndOffset + layoutInfo.viewportStartOffset) / 2
-            val itemCenter = itemInfo.offset + itemInfo.size / 2
-            val diff = itemCenter - viewportCenter
-            if (diff != 0) {
-                listState.animateScrollBy(diff.toFloat())
-            }
-        }
-    }
-
-    LazyRow(
-        state = listState,
-        horizontalArrangement = Arrangement.spacedBy(itemSpacing),
+    BoxWithConstraints(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 32.dp),
-        contentPadding = PaddingValues(horizontal = 48.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .padding(horizontal = 32.dp)
     ) {
-        itemsIndexed(games) { index, game ->
-            val isSelected = index == centerItemIndex
+        val horizontalPadding = (maxWidth - itemSize) / 2
+
+        HorizontalPager(
+            state = pagerState,
+            pageSize = PageSize.Fixed(itemSize),
+            pageSpacing = itemSpacing,
+            contentPadding = PaddingValues(horizontal = horizontalPadding),
+            verticalAlignment = Alignment.CenterVertically,
+            flingBehavior = PagerDefaults.flingBehavior(
+                state = pagerState,
+                pagerSnapDistance = PagerSnapDistance.atMost(1)
+            )
+        ) { page ->
+            val game = games[page]
+            val isSelected = pagerState.currentPage == page
             val size by animateDpAsState(
                 targetValue = if (isSelected) itemSize * selectedScale else itemSize,
                 label = "SizeAnimation"


### PR DESCRIPTION
## Summary
- switch game carousel from LazyRow to HorizontalPager
- calculate padding so the first and last icons center
- snap scrolling to at most one item per fling

## Testing
- `./gradlew test` *(fails: could not finish due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_687a40ac59c4832786d18cba6787c106