### PR TITLE
Fix top status bar layering

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -45,7 +45,6 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
 
     Surface(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.fillMaxSize()) {
-            StatusTopBar(modifier = Modifier.align(Alignment.TopCenter))
             Box(
                 modifier = Modifier
                     .fillMaxSize(),
@@ -61,6 +60,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     }
                 }
             }
+            StatusTopBar(modifier = Modifier.align(Alignment.TopCenter))
         }
 
     }


### PR DESCRIPTION
## Summary
- keep the custom status bar visible above the game carousel

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_687c538a526883278471a96b38afb43f