### PR TITLE
Add navigation bottom bar

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.retrobreeze.ribbonlauncher.GameCarousel
 import com.retrobreeze.ribbonlauncher.StatusTopBar
+import com.retrobreeze.ribbonlauncher.NavigationBottomBar
 import com.retrobreeze.ribbonlauncher.ui.theme.RibbonLauncherTheme
 
 class MainActivity : ComponentActivity() {
@@ -61,6 +62,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                 }
             }
             StatusTopBar(modifier = Modifier.align(Alignment.TopCenter))
+            NavigationBottomBar(modifier = Modifier.align(Alignment.BottomCenter))
         }
 
     }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/NavigationBottomBar.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/NavigationBottomBar.kt
@@ -1,0 +1,78 @@
+package com.retrobreeze.ribbonlauncher
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun NavigationBottomBar(
+    modifier: Modifier = Modifier,
+    onLeftClick: () -> Unit = {},
+    onCenterClick: () -> Unit = {},
+    onRightClick: () -> Unit = {}
+) {
+    val isDark = isSystemInDarkTheme()
+    val gradient = remember(isDark) {
+        val tint = if (isDark) Color.Black else Color.White
+        Brush.verticalGradient(
+            colors = listOf(tint.copy(alpha = if (isDark) 0.12f else 0.18f), Color.Transparent)
+        )
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(64.dp)
+            .background(gradient)
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Button(
+                onClick = onLeftClick,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+            ) {
+                Text("Left")
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Button(
+                onClick = onCenterClick,
+                modifier = Modifier
+                    .weight(3f)
+                    .fillMaxHeight()
+            ) {
+                Text("Center")
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Button(
+                onClick = onRightClick,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+            ) {
+                Text("Right")
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun NavigationBottomBarPreview() {
+    NavigationBottomBar()
+}


### PR DESCRIPTION
## Summary
- add a bottom navigation bar composable with 3 buttons
- include the bottom bar in `LauncherScreen`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c86aab2b083278ccad0096b87274f