### PR TITLE
Add icon reflection effect

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -23,9 +23,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.*
 import androidx.compose.ui.tooling.preview.Preview
 import com.retrobreeze.ribbonlauncher.model.GameEntry
-import com.retrobreeze.ribbonlauncher.ui.components.GameIconFancy
-import com.retrobreeze.ribbonlauncher.ui.components.GameIconSimple
-import com.retrobreeze.ribbonlauncher.util.isIconLikelyCircular
+import com.retrobreeze.ribbonlauncher.ui.components.GameIconWithReflection
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
@@ -71,6 +69,7 @@ fun GameCarousel(
                         targetValue = if (isSelected) itemSize * selectedScale else itemSize,
                         label = "SizeAnimation"
                     )
+                    val reflectionRatio = 0.4f
 
                     Box(
                         modifier = Modifier.fillMaxWidth(),
@@ -78,7 +77,8 @@ fun GameCarousel(
                     ) {
                         Box(
                             modifier = Modifier
-                                .size(size)
+                                .width(size)
+                                .height(size * (1f + reflectionRatio))
                                 .clickable {
                                     if (isSelected) {
                                         onLaunch(game)
@@ -88,14 +88,10 @@ fun GameCarousel(
                                         }
                                     }
                                 },
-                            contentAlignment = Alignment.Center
+                            contentAlignment = Alignment.TopCenter
                         ) {
                             game.icon?.let { icon ->
-                                if (isIconLikelyCircular(icon)) {
-                                    GameIconFancy(icon = icon, contentDesc = game.displayName)
-                                } else {
-                                    GameIconSimple(icon = icon, contentDesc = game.displayName)
-                                }
+                                GameIconWithReflection(icon = icon, contentDesc = game.displayName)
                             }
                         }
                     }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -91,7 +91,12 @@ fun GameCarousel(
                             contentAlignment = Alignment.TopCenter
                         ) {
                             game.icon?.let { icon ->
-                                GameIconWithReflection(icon = icon, contentDesc = game.displayName)
+                                GameIconWithReflection(
+                                    icon = icon,
+                                    contentDesc = game.displayName,
+                                    iconSize = size,
+                                    reflectionRatio = reflectionRatio
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -1,0 +1,78 @@
+package com.retrobreeze.ribbonlauncher.ui.components
+
+import android.graphics.drawable.Drawable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.retrobreeze.ribbonlauncher.util.isIconLikelyCircular
+
+/**
+ * Displays a game icon with a subtle reflection beneath it.
+ */
+@Composable
+fun GameIconWithReflection(
+    icon: Drawable,
+    contentDesc: String,
+    modifier: Modifier = Modifier,
+    reflectionRatio: Float = 0.4f
+) {
+    val isCircular = isIconLikelyCircular(icon)
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+        ) {
+            if (isCircular) {
+                GameIconFancy(icon = icon, contentDesc = contentDesc)
+            } else {
+                GameIconSimple(icon = icon, contentDesc = contentDesc)
+            }
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(reflectionRatio)
+                .graphicsLayer {
+                    scaleY = -1f
+                }
+        ) {
+            if (isCircular) {
+                GameIconFancy(icon = icon, contentDesc = "")
+            } else {
+                GameIconSimple(icon = icon, contentDesc = "")
+            }
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(
+                        Brush.verticalGradient(
+                            0f to Color.Black.copy(alpha = 0.4f),
+                            1f to Color.Transparent
+                        )
+                    )
+            )
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+    }
+}
+
+
+@Preview
+@Composable
+fun GameIconWithReflectionPreview() {
+    val drawable = android.graphics.drawable.ColorDrawable(android.graphics.Color.DKGRAY)
+    GameIconWithReflection(icon = drawable, contentDesc = "Preview")
+}
+

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -1,14 +1,14 @@
 package com.retrobreeze.ribbonlauncher.ui.components
 
 import android.graphics.drawable.Drawable
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.retrobreeze.ribbonlauncher.util.isIconLikelyCircular
@@ -46,6 +46,17 @@ fun GameIconWithReflection(
                 .weight(reflectionRatio)
                 .graphicsLayer {
                     scaleY = -1f
+                    clip = true
+                }
+                .drawWithCache {
+                    val gradient = Brush.verticalGradient(
+                        0f to Color.Black.copy(alpha = 0.4f),
+                        1f to Color.Transparent
+                    )
+                    onDrawWithContent {
+                        drawContent()
+                        drawRect(gradient, blendMode = androidx.compose.ui.graphics.BlendMode.DstIn)
+                    }
                 }
         ) {
             if (isCircular) {
@@ -53,16 +64,6 @@ fun GameIconWithReflection(
             } else {
                 GameIconSimple(icon = icon, contentDesc = "")
             }
-            Box(
-                modifier = Modifier
-                    .matchParentSize()
-                    .background(
-                        Brush.verticalGradient(
-                            0f to Color.Black.copy(alpha = 0.4f),
-                            1f to Color.Transparent
-                        )
-                    )
-            )
         }
         Spacer(modifier = Modifier.height(4.dp))
     }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -5,12 +5,16 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalDensity
 import com.retrobreeze.ribbonlauncher.util.isIconLikelyCircular
 
 /**
@@ -20,19 +24,20 @@ import com.retrobreeze.ribbonlauncher.util.isIconLikelyCircular
 fun GameIconWithReflection(
     icon: Drawable,
     contentDesc: String,
+    iconSize: Dp,
     modifier: Modifier = Modifier,
     reflectionRatio: Float = 0.4f
 ) {
     val isCircular = isIconLikelyCircular(icon)
+    val reflectionHeight = iconSize * reflectionRatio
 
-    Column(
+    Box(
         modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally
+        contentAlignment = Alignment.TopCenter
     ) {
         Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
+                .size(iconSize)
         ) {
             if (isCircular) {
                 GameIconFancy(icon = icon, contentDesc = contentDesc)
@@ -40,14 +45,15 @@ fun GameIconWithReflection(
                 GameIconSimple(icon = icon, contentDesc = contentDesc)
             }
         }
+
+        val offsetPx = with(LocalDensity.current) { iconSize.roundToPx() }
+
         Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .weight(reflectionRatio)
-                .graphicsLayer {
-                    scaleY = -1f
-                    clip = true
-                }
+                .offset { IntOffset(0, offsetPx) }
+                .height(reflectionHeight)
+                .width(iconSize)
+                .graphicsLayer { clip = true }
                 .drawWithCache {
                     val gradient = Brush.verticalGradient(
                         colors = listOf(
@@ -59,12 +65,22 @@ fun GameIconWithReflection(
                         drawContent()
                         drawRect(gradient, blendMode = androidx.compose.ui.graphics.BlendMode.DstIn)
                     }
-                }
+                },
+            contentAlignment = Alignment.TopCenter
         ) {
-            if (isCircular) {
-                GameIconFancy(icon = icon, contentDesc = "")
-            } else {
-                GameIconSimple(icon = icon, contentDesc = "")
+            Box(
+                modifier = Modifier
+                    .size(iconSize)
+                    .graphicsLayer {
+                        scaleY = -1f
+                        transformOrigin = TransformOrigin(0.5f, 0f)
+                    }
+            ) {
+                if (isCircular) {
+                    GameIconFancy(icon = icon, contentDesc = "")
+                } else {
+                    GameIconSimple(icon = icon, contentDesc = "")
+                }
             }
         }
     }
@@ -75,6 +91,10 @@ fun GameIconWithReflection(
 @Composable
 fun GameIconWithReflectionPreview() {
     val drawable = android.graphics.drawable.ColorDrawable(android.graphics.Color.DKGRAY)
-    GameIconWithReflection(icon = drawable, contentDesc = "Preview")
+    GameIconWithReflection(
+        icon = drawable,
+        contentDesc = "Preview",
+        iconSize = 100.dp
+    )
 }
 

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -50,8 +50,10 @@ fun GameIconWithReflection(
                 }
                 .drawWithCache {
                     val gradient = Brush.verticalGradient(
-                        0f to Color.Black.copy(alpha = 0.4f),
-                        1f to Color.Transparent
+                        colors = listOf(
+                            Color.Black.copy(alpha = 0.4f),
+                            Color.Transparent
+                        )
                     )
                     onDrawWithContent {
                         drawContent()
@@ -65,7 +67,6 @@ fun GameIconWithReflection(
                 GameIconSimple(icon = icon, contentDesc = "")
             }
         }
-        Spacer(modifier = Modifier.height(4.dp))
     }
 }
 

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -5,9 +5,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithCache
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
@@ -53,19 +50,7 @@ fun GameIconWithReflection(
                 .offset { IntOffset(0, offsetPx) }
                 .height(reflectionHeight)
                 .width(iconSize)
-                .graphicsLayer { clip = true }
-                .drawWithCache {
-                    val gradient = Brush.verticalGradient(
-                        colors = listOf(
-                            Color.Black.copy(alpha = 0.4f),
-                            Color.Transparent
-                        )
-                    )
-                    onDrawWithContent {
-                        drawContent()
-                        drawRect(gradient, blendMode = androidx.compose.ui.graphics.BlendMode.DstIn)
-                    }
-                },
+                .graphicsLayer { clip = true },
             contentAlignment = Alignment.TopCenter
         ) {
             Box(


### PR DESCRIPTION
## Summary
- create `GameIconWithReflection` composable to draw a flipped reflection below each icon
- show this effect in `GameCarousel` with room for the reflection

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_687cd0786a408327a1cad43ad835eaa2