### PR TITLE
Add carousel sorting with sort button

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -33,9 +33,9 @@ import kotlin.math.roundToInt
 @Composable
 fun GameCarousel(
     games: List<GameEntry>,
+    pagerState: PagerState,
     onLaunch: (GameEntry) -> Unit
 ) {
-    val pagerState = rememberPagerState(initialPage = 0) { games.size }
     val coroutineScope = rememberCoroutineScope()
     val itemSpacing = 32.dp
     val itemSize = 150.dp
@@ -194,5 +194,6 @@ fun GameCarouselDebugPreview() {
         GameEntry("com.example.two", "Gyro", ColorDrawable(Color.Gray.toArgb())),
         GameEntry("com.example.three", "Yeti", ColorDrawable(Color.Gray.toArgb()))
     )
-    GameCarousel(games = sampleGames, onLaunch = {})
+    val state = rememberPagerState(initialPage = 0) { sampleGames.size }
+    GameCarousel(games = sampleGames, pagerState = state, onLaunch = {})
 }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -59,6 +59,8 @@ fun GameCarousel(
         val newSelectedIndex = games.indexOfFirst { it.packageName == selectedPackage }.takeIf { it != -1 } ?: pagerState.currentPage
         val indexOffset = newSelectedIndex - oldSelectedIndex
 
+        pagerState.scrollToPage(newSelectedIndex)
+
         games.forEachIndexed { index, game ->
             val prev = previousIndices[game.packageName] ?: index
             val anim = animatables.getOrPut(game.packageName) { Animatable(0f) }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.zIndex
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.toArgb
@@ -45,6 +46,7 @@ fun GameCarousel(
     val density = LocalDensity.current
     val animatables = remember { mutableMapOf<String, Animatable<Float, AnimationVector1D>>() }
     var previousIndices by remember { mutableStateOf<Map<String, Int>>(emptyMap()) }
+    var selectedPackageName by remember { mutableStateOf<String?>(null) }
     val itemSpacing = 32.dp
     val itemSize = 150.dp
     val selectedScale = 1.25f
@@ -52,9 +54,7 @@ fun GameCarousel(
 
     LaunchedEffect(games) {
         val itemWidthPx = with(density) { (maxPageWidth + itemSpacing).toPx() }
-        val previouslySelected = previousIndices.entries
-            .firstOrNull { it.value == pagerState.currentPage }
-            ?.key
+        val previouslySelected = selectedPackageName
 
         games.forEachIndexed { index, game ->
             val prev = previousIndices[game.packageName] ?: index
@@ -67,6 +67,10 @@ fun GameCarousel(
             }
         }
         previousIndices = games.mapIndexed { i, g -> g.packageName to i }.toMap()
+    }
+
+    LaunchedEffect(pagerState.currentPage, games) {
+        selectedPackageName = games.getOrNull(pagerState.currentPage)?.packageName
     }
 
     Box(
@@ -104,7 +108,8 @@ fun GameCarousel(
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .graphicsLayer { translationX = offset },
+                            .graphicsLayer { translationX = offset }
+                            .zIndex(if (isSelected) 1f else 0f),
                         contentAlignment = Alignment.Center
                     ) {
                         Box(

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -52,12 +52,19 @@ fun GameCarousel(
 
     LaunchedEffect(games) {
         val itemWidthPx = with(density) { (maxPageWidth + itemSpacing).toPx() }
+        val previouslySelected = previousIndices.entries
+            .firstOrNull { it.value == pagerState.currentPage }
+            ?.key
+
         games.forEachIndexed { index, game ->
             val prev = previousIndices[game.packageName] ?: index
             val anim = animatables.getOrPut(game.packageName) { Animatable(0f) }
             val delta = (prev - index) * itemWidthPx
-            anim.snapTo(delta)
-            launch { anim.animateTo(0f, animationSpec = tween(durationMillis = 300)) }
+            val start = if (game.packageName == previouslySelected) 0f else delta
+            anim.snapTo(start)
+            if (start != 0f) {
+                launch { anim.animateTo(0f, animationSpec = tween(durationMillis = 300)) }
+            }
         }
         previousIndices = games.mapIndexed { i, g -> g.packageName to i }.toMap()
     }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -40,13 +40,13 @@ import kotlin.math.roundToInt
 fun GameCarousel(
     games: List<GameEntry>,
     pagerState: PagerState,
+    selectedPackageName: String?,
     onLaunch: (GameEntry) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val density = LocalDensity.current
     val animatables = remember { mutableMapOf<String, Animatable<Float, AnimationVector1D>>() }
     var previousIndices by remember { mutableStateOf<Map<String, Int>>(emptyMap()) }
-    var selectedPackageName by remember { mutableStateOf<String?>(null) }
     val itemSpacing = 32.dp
     val itemSize = 150.dp
     val selectedScale = 1.25f
@@ -73,10 +73,6 @@ fun GameCarousel(
         }
 
         previousIndices = games.mapIndexed { i, g -> g.packageName to i }.toMap()
-    }
-
-    LaunchedEffect(pagerState.currentPage) {
-        selectedPackageName = games.getOrNull(pagerState.currentPage)?.packageName
     }
 
     Box(
@@ -237,5 +233,10 @@ fun GameCarouselDebugPreview() {
         GameEntry("com.example.three", "Yeti", ColorDrawable(Color.Gray.toArgb()))
     )
     val state = rememberPagerState(initialPage = 0) { sampleGames.size }
-    GameCarousel(games = sampleGames, pagerState = state, onLaunch = {})
+    GameCarousel(
+        games = sampleGames,
+        pagerState = state,
+        selectedPackageName = sampleGames.first().packageName,
+        onLaunch = {}
+    )
 }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -54,22 +54,26 @@ fun GameCarousel(
 
     LaunchedEffect(games) {
         val itemWidthPx = with(density) { (maxPageWidth + itemSpacing).toPx() }
-        val previouslySelected = selectedPackageName
+        val selectedPackage = selectedPackageName
+        val oldSelectedIndex = previousIndices[selectedPackage] ?: pagerState.currentPage
+        val newSelectedIndex = games.indexOfFirst { it.packageName == selectedPackage }.takeIf { it != -1 } ?: pagerState.currentPage
+        val indexOffset = newSelectedIndex - oldSelectedIndex
 
         games.forEachIndexed { index, game ->
             val prev = previousIndices[game.packageName] ?: index
             val anim = animatables.getOrPut(game.packageName) { Animatable(0f) }
-            val delta = (prev - index) * itemWidthPx
-            val start = if (game.packageName == previouslySelected) 0f else delta
+            val delta = (prev - index + indexOffset) * itemWidthPx
+            val start = if (game.packageName == selectedPackage) 0f else delta
             anim.snapTo(start)
             if (start != 0f) {
                 launch { anim.animateTo(0f, animationSpec = tween(durationMillis = 300)) }
             }
         }
+
         previousIndices = games.mapIndexed { i, g -> g.packageName to i }.toMap()
     }
 
-    LaunchedEffect(pagerState.currentPage, games) {
+    LaunchedEffect(pagerState.currentPage) {
         selectedPackageName = games.getOrNull(pagerState.currentPage)?.packageName
     }
 

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -91,7 +91,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     viewModel.cycleSortMode()
                     val newIndex = viewModel.games.indexOfFirst { it.packageName == current?.packageName }
                         .coerceAtLeast(0)
-                    coroutineScope.launch { pagerState.animateScrollToPage(newIndex) }
+                    coroutineScope.launch { pagerState.scrollToPage(newIndex) }
                 },
                 modifier = Modifier
                     .align(Alignment.TopStart)

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -54,6 +55,11 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
     val context = LocalContext.current
     var showDrawer by remember { mutableStateOf(false) }
     val pagerState = rememberPagerState(initialPage = 0) { games.size }
+    var selectedPackageName by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(pagerState.currentPage, games) {
+        selectedPackageName = games.getOrNull(pagerState.currentPage)?.packageName
+    }
 
     Surface(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.fillMaxSize()) {
@@ -64,7 +70,11 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     .padding(top = 32.dp, bottom = 64.dp),
                 contentAlignment = Alignment.Center
             ) {
-                GameCarousel(games, pagerState) { game ->
+                GameCarousel(
+                    games = games,
+                    pagerState = pagerState,
+                    selectedPackageName = selectedPackageName,
+                ) { game ->
                     val intent = context.packageManager.getLaunchIntentForPackage(game.packageName)
                     if (intent != null) {
                         context.startActivity(intent)

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -15,14 +15,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.foundation.pager.rememberPagerState
-import kotlinx.coroutines.launch
 import com.retrobreeze.ribbonlauncher.GameCarousel
 import com.retrobreeze.ribbonlauncher.SortButton
 import com.retrobreeze.ribbonlauncher.StatusTopBar
@@ -56,7 +54,6 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
     val context = LocalContext.current
     var showDrawer by remember { mutableStateOf(false) }
     val pagerState = rememberPagerState(initialPage = 0) { games.size }
-    val coroutineScope = rememberCoroutineScope()
 
     Surface(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.fillMaxSize()) {
@@ -87,11 +84,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
             SortButton(
                 sortMode = sortMode,
                 onClick = {
-                    val current = games.getOrNull(pagerState.currentPage)
                     viewModel.cycleSortMode()
-                    val newIndex = viewModel.games.indexOfFirst { it.packageName == current?.packageName }
-                        .coerceAtLeast(0)
-                    coroutineScope.launch { pagerState.scrollToPage(newIndex) }
                 },
                 modifier = Modifier
                     .align(Alignment.TopStart)

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/SortButton.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/SortButton.kt
@@ -1,6 +1,5 @@
 package com.retrobreeze.ribbonlauncher
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -10,13 +9,12 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.delay
 
 @Composable
 fun SortButton(
@@ -24,28 +22,18 @@ fun SortButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var visible by remember { mutableStateOf(false) }
-
-    LaunchedEffect(sortMode) {
-        visible = true
-        delay(1500)
-        visible = false
-    }
-
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         IconButton(
             onClick = onClick,
-            colors = IconButtonDefaults.iconButtonColors(containerColor = Color.Transparent)
+            colors = IconButtonDefaults.iconButtonColors(containerColor = Color.Transparent),
         ) {
             Icon(imageVector = Icons.Default.Sort, contentDescription = "Sort")
         }
-        AnimatedVisibility(visible) {
-            Text(
-                text = sortMode.label,
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(start = 4.dp)
-            )
-        }
+        Text(
+            text = sortMode.label,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(start = 4.dp)
+        )
     }
 }
 

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/SortButton.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/SortButton.kt
@@ -7,11 +7,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Sort
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
@@ -31,7 +33,10 @@ fun SortButton(
     }
 
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
-        IconButton(onClick = onClick) {
+        IconButton(
+            onClick = onClick,
+            colors = IconButtonDefaults.iconButtonColors(containerColor = Color.Transparent)
+        ) {
             Icon(imageVector = Icons.Default.Sort, contentDescription = "Sort")
         }
         AnimatedVisibility(visible) {

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/SortButton.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/SortButton.kt
@@ -1,0 +1,51 @@
+package com.retrobreeze.ribbonlauncher
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Sort
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+@Composable
+fun SortButton(
+    sortMode: SortMode,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var visible by remember { mutableStateOf(false) }
+
+    LaunchedEffect(sortMode) {
+        visible = true
+        delay(1500)
+        visible = false
+    }
+
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        IconButton(onClick = onClick) {
+            Icon(imageVector = Icons.Default.Sort, contentDescription = "Sort")
+        }
+        AnimatedVisibility(visible) {
+            Text(
+                text = sortMode.label,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(start = 4.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SortButtonPreview() {
+    SortButton(sortMode = SortMode.AZ, onClick = {})
+}

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/SortMode.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/SortMode.kt
@@ -1,0 +1,13 @@
+package com.retrobreeze.ribbonlauncher
+
+enum class SortMode(val label: String) {
+    AZ("A-Z"),
+    ZA("Z-A"),
+    RECENT("Recent");
+
+    fun next(): SortMode = when (this) {
+        AZ -> ZA
+        ZA -> RECENT
+        RECENT -> AZ
+    }
+}


### PR DESCRIPTION
## Summary
- support sorting modes A-Z, Z-A and Recent via `SortMode`
- store last launched time in `LauncherViewModel` and update sorting
- expose pager state to `GameCarousel` so selection persists on sort
- add `SortButton` composable and wire into `LauncherScreen`

## Testing
- `./gradlew assembleDebug`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_687d4726573483279599693e01ab3c07