### PR TITLE
Add DataStore persistence

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
 
     // For loading images like app icons
     implementation(libs.coil.compose)
+    implementation(libs.androidx.datastore.preferences)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherPreferences.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherPreferences.kt
@@ -1,0 +1,56 @@
+package com.retrobreeze.ribbonlauncher
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+
+val Context.launcherDataStore by preferencesDataStore("launcher_prefs")
+
+object LauncherPreferences {
+    val KEY_SORT_MODE = stringPreferencesKey("sort_mode")
+    val KEY_SELECTED_GAME = stringPreferencesKey("selected_game")
+    val KEY_LAST_PLAYED = stringPreferencesKey("last_played")
+}
+
+private fun encodeLastPlayed(map: Map<String, Long>): String =
+    map.entries.joinToString(";") { "${it.key}:${it.value}" }
+
+private fun decodeLastPlayed(str: String): Map<String, Long> =
+    str.split(';').mapNotNull {
+        val parts = it.split(':')
+        val timestamp = parts.getOrNull(1)?.toLongOrNull()
+        if (parts.size == 2 && timestamp != null) parts[0] to timestamp else null
+    }.toMap()
+
+suspend fun Context.saveSortMode(mode: SortMode) {
+    launcherDataStore.edit { it[LauncherPreferences.KEY_SORT_MODE] = mode.name }
+}
+
+suspend fun Context.loadSortMode(): SortMode {
+    val prefs = launcherDataStore.data.first()
+    return prefs[LauncherPreferences.KEY_SORT_MODE]?.let { runCatching { SortMode.valueOf(it) }.getOrNull() } ?: SortMode.AZ
+}
+
+suspend fun Context.saveSelectedGame(packageName: String?) {
+    launcherDataStore.edit { prefs ->
+        if (packageName == null) prefs.remove(LauncherPreferences.KEY_SELECTED_GAME)
+        else prefs[LauncherPreferences.KEY_SELECTED_GAME] = packageName
+    }
+}
+
+suspend fun Context.loadSelectedGame(): String? {
+    val prefs = launcherDataStore.data.first()
+    return prefs[LauncherPreferences.KEY_SELECTED_GAME]
+}
+
+suspend fun Context.saveLastPlayed(map: Map<String, Long>) {
+    launcherDataStore.edit { it[LauncherPreferences.KEY_LAST_PLAYED] = encodeLastPlayed(map) }
+}
+
+suspend fun Context.loadLastPlayed(): Map<String, Long> {
+    val prefs = launcherDataStore.data.first()
+    val str = prefs[LauncherPreferences.KEY_LAST_PLAYED] ?: return emptyMap()
+    return decodeLastPlayed(str)
+}

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -52,13 +52,19 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
     val games = viewModel.games
     val sortMode = viewModel.sortMode
     val apps = viewModel.apps
+    val persistedSelected = viewModel.selectedGamePackageName
     val context = LocalContext.current
     var showDrawer by remember { mutableStateOf(false) }
     val pagerState = rememberPagerState(initialPage = 0) { games.size }
-    var selectedPackageName by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(games) {
+        val index = games.indexOfFirst { it.packageName == persistedSelected }
+        if (index >= 0) pagerState.scrollToPage(index)
+    }
 
     LaunchedEffect(pagerState.currentPage, games) {
-        selectedPackageName = games.getOrNull(pagerState.currentPage)?.packageName
+        val pkg = games.getOrNull(pagerState.currentPage)?.packageName
+        viewModel.setSelectedGame(pkg)
     }
 
     Surface(modifier = Modifier.fillMaxSize()) {
@@ -73,7 +79,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                 GameCarousel(
                     games = games,
                     pagerState = pagerState,
-                    selectedPackageName = selectedPackageName,
+                    selectedPackageName = persistedSelected,
                 ) { game ->
                     val intent = context.packageManager.getLaunchIntentForPackage(game.packageName)
                     if (intent != null) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+dataStore = "1.1.0"
 
 [libraries]
 accompanist-blur = { module = "com.google.accompanist:accompanist-blur", version.ref = "accompanistBlur" }
@@ -29,6 +30,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "dataStore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- keep sort mode, last selection and recent order across app restarts
- add DataStore utilities
- persist user choices in `LauncherViewModel`
- restore last game on launch
- fix nullability bug in `decodeLastPlayed`

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_687df3bb4b7c8327a116dcb6333c8043