### PR TITLE
Add selected game persistence

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
@@ -15,6 +15,7 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         private const val PREFS_NAME = "launcher_prefs"
         private const val KEY_SORT_MODE = "sort_mode"
         private const val KEY_LAST_PLAYED_PREFIX = "lp_"
+        private const val KEY_SELECTED_GAME = "selected_game"
     }
 
     private val prefs = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -32,6 +33,9 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
 
     private val lastPlayed = mutableStateMapOf<String, Long>()
 
+    var selectedGamePackage by mutableStateOf<String?>(null)
+        private set
+
     init {
         loadPreferences()
         loadInstalledGames()
@@ -44,6 +48,8 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         } catch (_: IllegalArgumentException) {
             SortMode.AZ
         }
+
+        selectedGamePackage = prefs.getString(KEY_SELECTED_GAME, null)
 
         prefs.all.forEach { (key, value) ->
             if (key.startsWith(KEY_LAST_PLAYED_PREFIX)) {
@@ -125,6 +131,15 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         prefs.edit().putString(KEY_SORT_MODE, sortMode.name).apply()
 
         sortGames()
+    }
+
+    fun setSelectedGame(packageName: String?) {
+        selectedGamePackage = packageName
+        with(prefs.edit()) {
+            if (packageName == null) remove(KEY_SELECTED_GAME)
+            else putString(KEY_SELECTED_GAME, packageName)
+            apply()
+        }
     }
 
     fun recordLaunch(game: GameEntry) {

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -55,12 +55,10 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
     val context = LocalContext.current
     var showDrawer by remember { mutableStateOf(false) }
     val pagerState = rememberPagerState(initialPage = 0) { games.size }
-    var selectedPackageName by remember { mutableStateOf<String?>(null) }
 
-    
-    LaunchedEffect(pagerState.currentPage) {
-
-        selectedPackageName = games.getOrNull(pagerState.currentPage)?.packageName
+    LaunchedEffect(pagerState.currentPage, games) {
+        val pkg = games.getOrNull(pagerState.currentPage)?.packageName
+        viewModel.setSelectedGame(pkg)
     }
 
     Surface(modifier = Modifier.fillMaxSize()) {
@@ -75,7 +73,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                 GameCarousel(
                     games = games,
                     pagerState = pagerState,
-                    selectedPackageName = selectedPackageName,
+                    selectedPackageName = viewModel.selectedGamePackage,
                 ) { game ->
                     val intent = context.packageManager.getLaunchIntentForPackage(game.packageName)
                     if (intent != null) {


### PR DESCRIPTION
## Summary
- save and restore the last selected game using SharedPreferences
- expose selected game state from `LauncherViewModel`
- update `LauncherScreen` to persist selection and feed it to `GameCarousel`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687e102b18b08327b9c45c41694c542f