### PR TITLE
Remove padding around carousel

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -78,7 +78,6 @@ fun GameCarousel(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 32.dp)
     ) {
         Box(
             modifier = Modifier.align(Alignment.Center),


### PR DESCRIPTION
## Summary
- let the game carousel span edge-to-edge by removing its outer horizontal padding

## Testing
- `./gradlew test` *(fails: unable to finish due to Android tooling downloads)*

------
https://chatgpt.com/codex/tasks/task_e_687e447dbd008327baf9e0889fe25eb4