### PR TITLE
Implement icon reflection effect

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -26,8 +26,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.*
 import androidx.compose.ui.tooling.preview.Preview
 import com.retrobreeze.ribbonlauncher.model.GameEntry
-import com.retrobreeze.ribbonlauncher.ui.components.GameIconFancy
-import com.retrobreeze.ribbonlauncher.ui.components.GameIconSimple
+import com.retrobreeze.ribbonlauncher.ui.components.GameIconWithReflection
 import com.retrobreeze.ribbonlauncher.util.isIconLikelyCircular
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -116,7 +115,8 @@ fun GameCarousel(
                     ) {
                         Box(
                             modifier = Modifier
-                                .size(size)
+                                .width(size)
+                                .height(size * 1.25f)
                                 .clickable {
                                     if (isSelected) {
                                         onLaunch(game)
@@ -129,11 +129,12 @@ fun GameCarousel(
                             contentAlignment = Alignment.Center
                         ) {
                             game.icon?.let { icon ->
-                                if (isIconLikelyCircular(icon)) {
-                                    GameIconFancy(icon = icon, contentDesc = game.displayName)
-                                } else {
-                                    GameIconSimple(icon = icon, contentDesc = game.displayName)
-                                }
+                                GameIconWithReflection(
+                                    icon = icon,
+                                    contentDesc = game.displayName,
+                                    isCircular = isIconLikelyCircular(icon),
+                                    iconSize = size
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconFancy.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconFancy.kt
@@ -20,13 +20,12 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.core.graphics.drawable.toBitmap
 
 @Composable
-fun GameIconFancy(icon: Drawable, contentDesc: String) {
+fun GameIconFancy(icon: Drawable, contentDesc: String, modifier: Modifier = Modifier) {
     // Convert Drawable to Painter
     val painter: Painter = BitmapPainter(icon.toBitmap().asImageBitmap())
 
     Box(
-        modifier = Modifier
-            .fillMaxSize()
+        modifier = modifier
             .clip(RoundedCornerShape(12.dp))
             .background(Color.Black),
         contentAlignment = Alignment.Center

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconSimple.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconSimple.kt
@@ -2,7 +2,6 @@ package com.retrobreeze.ribbonlauncher.ui.components
 
 import android.graphics.drawable.Drawable
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -14,14 +13,13 @@ import androidx.compose.ui.unit.dp
 import androidx.core.graphics.drawable.toBitmap
 
 @Composable
-fun GameIconSimple(icon: Drawable, contentDesc: String) {
+fun GameIconSimple(icon: Drawable, contentDesc: String, modifier: Modifier = Modifier) {
     val painter = BitmapPainter(icon.toBitmap().asImageBitmap())
 
     Image(
         painter = painter,
         contentDescription = contentDesc,
-        modifier = Modifier
-            .fillMaxSize()
+        modifier = modifier
             .clip(RoundedCornerShape(12.dp)),
         contentScale = ContentScale.Crop
     )

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.BitmapPainter
@@ -34,7 +35,7 @@ fun GameIconWithReflection(
     modifier: Modifier = Modifier
 ) {
     val painter = BitmapPainter(icon.toBitmap().asImageBitmap())
-    val shape = RoundedCornerShape(12.dp)
+    val shape: Shape = if (isCircular) androidx.compose.foundation.shape.CircleShape else RoundedCornerShape(12.dp)
     val reflectionHeight = iconSize * 0.25f
 
     Column(
@@ -44,9 +45,17 @@ fun GameIconWithReflection(
     ) {
         Box(modifier = Modifier.size(iconSize)) {
             if (isCircular) {
-                GameIconFancy(icon = icon, contentDesc = contentDesc, modifier = Modifier.fillMaxSize())
+                GameIconFancy(
+                    icon = icon,
+                    contentDesc = contentDesc,
+                    modifier = Modifier.fillMaxSize()
+                )
             } else {
-                GameIconSimple(icon = icon, contentDesc = contentDesc, modifier = Modifier.fillMaxSize())
+                GameIconSimple(
+                    icon = icon,
+                    contentDesc = contentDesc,
+                    modifier = Modifier.fillMaxSize()
+                )
             }
         }
 

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -1,26 +1,22 @@
 package com.retrobreeze.ribbonlauncher.ui.components
 
 import android.graphics.drawable.Drawable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
-import androidx.compose.ui.graphics.BlendMode
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.*
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.core.graphics.drawable.toBitmap
 
 @Composable
 fun GameIconWithReflection(
@@ -63,7 +59,7 @@ fun GameIconWithReflection(
                 .drawWithCache {
                     val gradient = Brush.verticalGradient(
                         colors = listOf(
-                            Color.Black.copy(alpha = 0.4f),
+                            Color.White.copy(alpha = 0.4f),
                             Color.Transparent
                         )
                     )
@@ -73,19 +69,13 @@ fun GameIconWithReflection(
                     }
                 }
         ) {
-            if (isCircular) {
-                GameIconFancy(
-                    icon = icon,
-                    contentDesc = contentDesc,
-                    modifier = Modifier.fillMaxSize()
-                )
-            } else {
-                GameIconSimple(
-                    icon = icon,
-                    contentDesc = contentDesc,
-                    modifier = Modifier.fillMaxSize()
-                )
-            }
+            val painter = remember(icon) { BitmapPainter(icon.toBitmap().asImageBitmap()) }
+            Image(
+                painter = painter,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = if (isCircular) ContentScale.Fit else ContentScale.Crop
+            )
         }
     }
 }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -49,21 +49,20 @@ fun GameIconWithReflection(
                 GameIconSimple(icon = icon, contentDesc = contentDesc, modifier = Modifier.fillMaxSize())
             }
         }
+
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(reflectionHeight)
                 .clip(shape)
-                .graphicsLayer {
-                    scaleY = -1f
-                }
+                .graphicsLayer { scaleY = -1f }
                 .drawWithCache {
                     val gradient = Brush.verticalGradient(
-                        colors = listOf(Color.Black.copy(alpha = 0.4f), Color.Transparent)
+                        colors = listOf(Color.White.copy(alpha = 0.4f), Color.Transparent)
                     )
                     onDrawWithContent {
                         drawContent()
-                        drawRect(brush = gradient, blendMode = BlendMode.DstIn)
+                        drawRect(gradient, blendMode = BlendMode.DstIn)
                     }
                 }
         ) {

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -1,0 +1,78 @@
+package com.retrobreeze.ribbonlauncher.ui.components
+
+import android.graphics.drawable.Drawable
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.drawable.toBitmap
+
+@Composable
+fun GameIconWithReflection(
+    icon: Drawable,
+    contentDesc: String,
+    isCircular: Boolean,
+    iconSize: Dp,
+    modifier: Modifier = Modifier
+) {
+    val painter = BitmapPainter(icon.toBitmap().asImageBitmap())
+    val shape = RoundedCornerShape(12.dp)
+    val reflectionHeight = iconSize * 0.25f
+
+    Column(
+        modifier = modifier
+            .size(width = iconSize, height = iconSize + reflectionHeight),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(modifier = Modifier.size(iconSize)) {
+            if (isCircular) {
+                GameIconFancy(icon = icon, contentDesc = contentDesc, modifier = Modifier.fillMaxSize())
+            } else {
+                GameIconSimple(icon = icon, contentDesc = contentDesc, modifier = Modifier.fillMaxSize())
+            }
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(reflectionHeight)
+                .clip(shape)
+                .graphicsLayer {
+                    scaleY = -1f
+                }
+                .drawWithCache {
+                    val gradient = Brush.verticalGradient(
+                        colors = listOf(Color.Black.copy(alpha = 0.4f), Color.Transparent)
+                    )
+                    onDrawWithContent {
+                        drawContent()
+                        drawRect(brush = gradient, blendMode = BlendMode.DstIn)
+                    }
+                }
+        ) {
+            Image(
+                painter = painter,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -71,10 +71,8 @@ fun GameIconWithReflection(
                         1f to Color.Transparent
                     )
                     onDrawWithContent {
-                        withLayer {
-                            drawContent()
-                            drawRect(gradient, blendMode = BlendMode.DstIn)
-                        }
+                        drawContent()
+                        drawRect(gradient, blendMode = BlendMode.DstIn)
                     }
                 }
         ) {

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -5,10 +5,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,7 +36,7 @@ fun GameIconWithReflection(
     modifier: Modifier = Modifier
 ) {
     val painter = BitmapPainter(icon.toBitmap().asImageBitmap())
-    val shape: Shape = if (isCircular) androidx.compose.foundation.shape.CircleShape else RoundedCornerShape(12.dp)
+    val shape: Shape = if (isCircular) CircleShape else RoundedCornerShape(12.dp)
     val reflectionHeight = iconSize * 0.25f
 
     Column(
@@ -67,8 +68,10 @@ fun GameIconWithReflection(
                 .graphicsLayer { scaleY = -1f }
                 .drawWithCache {
                     val gradient = Brush.verticalGradient(
-                        0f to Color.Black.copy(alpha = 0.4f),
-                        1f to Color.Transparent
+                        colors = listOf(
+                            Color.White.copy(alpha = 0.4f),
+                            Color.Transparent
+                        )
                     )
                     onDrawWithContent {
                         drawContent()

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -67,11 +67,14 @@ fun GameIconWithReflection(
                 .graphicsLayer { scaleY = -1f }
                 .drawWithCache {
                     val gradient = Brush.verticalGradient(
-                        colors = listOf(Color.White.copy(alpha = 0.4f), Color.Transparent)
+                        0f to Color.Black.copy(alpha = 0.4f),
+                        1f to Color.Transparent
                     )
                     onDrawWithContent {
-                        drawContent()
-                        drawRect(gradient, blendMode = BlendMode.DstIn)
+                        withLayer {
+                            drawContent()
+                            drawRect(gradient, blendMode = BlendMode.DstIn)
+                        }
                     }
                 }
         ) {

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -65,7 +65,6 @@ fun GameIconWithReflection(
                 .fillMaxWidth()
                 .height(reflectionHeight)
                 .clip(shape)
-                .graphicsLayer { scaleY = -1f }
                 .drawWithCache {
                     val gradient = Brush.verticalGradient(
                         colors = listOf(
@@ -82,7 +81,9 @@ fun GameIconWithReflection(
             Image(
                 painter = painter,
                 contentDescription = null,
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer { scaleY = -1f },
                 contentScale = ContentScale.Crop
             )
         }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -1,7 +1,6 @@
 package com.retrobreeze.ribbonlauncher.ui.components
 
 import android.graphics.drawable.Drawable
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,13 +18,9 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.painter.BitmapPainter
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.drawable.toBitmap
 
 @Composable
 fun GameIconWithReflection(
@@ -35,7 +30,6 @@ fun GameIconWithReflection(
     iconSize: Dp,
     modifier: Modifier = Modifier
 ) {
-    val painter = BitmapPainter(icon.toBitmap().asImageBitmap())
     val shape: Shape = if (isCircular) CircleShape else RoundedCornerShape(12.dp)
     val reflectionHeight = iconSize * 0.25f
 
@@ -65,10 +59,11 @@ fun GameIconWithReflection(
                 .fillMaxWidth()
                 .height(reflectionHeight)
                 .clip(shape)
+                .graphicsLayer { scaleY = -1f }
                 .drawWithCache {
                     val gradient = Brush.verticalGradient(
                         colors = listOf(
-                            Color.White.copy(alpha = 0.4f),
+                            Color.Black.copy(alpha = 0.4f),
                             Color.Transparent
                         )
                     )
@@ -78,14 +73,19 @@ fun GameIconWithReflection(
                     }
                 }
         ) {
-            Image(
-                painter = painter,
-                contentDescription = null,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .graphicsLayer { scaleY = -1f },
-                contentScale = ContentScale.Crop
-            )
+            if (isCircular) {
+                GameIconFancy(
+                    icon = icon,
+                    contentDesc = contentDesc,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                GameIconSimple(
+                    icon = icon,
+                    contentDesc = contentDesc,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add new `GameIconWithReflection` composable that mirrors the icon with a gradient fade
- allow `GameIconFancy` and `GameIconSimple` to accept a `Modifier`
- use the reflection component inside `GameCarousel`

## Testing
- `./gradlew assembleDebug -x lint` *(failed: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_687e5471b81083278ec6e0959b3da44a