### PR TITLE
Add reflected game icon component

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameIconWithReflection.kt
@@ -1,0 +1,88 @@
+package com.retrobreeze.ribbonlauncher.ui.components
+
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.drawable.toBitmap
+
+@Composable
+fun GameIconWithReflection(
+    icon: Drawable,
+    contentDesc: String,
+    modifier: Modifier = Modifier
+) {
+    val painter: Painter = BitmapPainter(icon.toBitmap().asImageBitmap())
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+    ) {
+        Image(
+            painter = painter,
+            contentDescription = contentDesc,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop
+        )
+
+        // Reflection
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(60.dp)
+        ) {
+            Image(
+                painter = painter,
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        scaleY = -1f
+                        transformOrigin = TransformOrigin(0.5f, 0f)
+                    },
+                contentScale = ContentScale.Crop
+            )
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(
+                        Brush.verticalGradient(
+                            0f to Color.Black.copy(alpha = 0.4f),
+                            1f to Color.Transparent
+                        )
+                    )
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun GameIconWithReflectionPreview() {
+    GameIconWithReflection(
+        icon = ColorDrawable(Color.Gray.toArgb()),
+        contentDesc = "Game",
+        modifier = Modifier.height(120.dp)
+    )
+}


### PR DESCRIPTION
## Summary
- add `GameIconWithReflection` composable showing a reflected icon
- fix preview color conversion import

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687ea541f02c8327b28f0c35a92923d8