### PR TITLE
Fix build by annotating MainActivity with ExperimentalFoundationApi

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -54,6 +54,7 @@ class MainActivity : ComponentActivity() {
 }
 
 
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
     val games = viewModel.games


### PR DESCRIPTION
## Summary
- annotate `LauncherScreen` composable in MainActivity with `@OptIn` for `ExperimentalFoundationApi`

## Testing
- `./gradlew assembleDebug --no-daemon --stacktrace`

------
https://chatgpt.com/codex/tasks/task_e_687f811772e883279902b9c52e0a6918