### PR TITLE
Add rounded clipping to icon reflections

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -235,6 +235,7 @@ fun ReflectiveGameIcon(
             modifier = Modifier
                 .height(iconSize * 0.25f)
                 .width(iconSize)
+                .clip(RoundedCornerShape(12.dp))
                 .drawWithCache {
                     val gradient = Brush.verticalGradient(
                         colors = listOf(Color.White.copy(alpha = 0.5f), Color.Transparent),

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MinimalGameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MinimalGameCarousel.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.*
@@ -19,6 +20,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.foundation.shape.RoundedCornerShape
 import com.retrobreeze.ribbonlauncher.model.GameEntry
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -69,6 +71,7 @@ fun ReflectiveGameIconWithGradient(
             modifier = Modifier
                 .height(iconSize * 0.25f)
                 .width(iconSize)
+                .clip(RoundedCornerShape(12.dp))
                 .drawWithCache {
                     val gradient = Brush.verticalGradient(
                         colors = listOf(

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/ReflectiveGameIcon.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/ReflectiveGameIcon.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -38,6 +40,7 @@ fun ReflectiveGameIcon(
             contentDescription = null,
             modifier = Modifier
                 .fillMaxSize()
+                .clip(RoundedCornerShape(12.dp))
                 .graphicsLayer {
                     scaleY = -1f
                 },


### PR DESCRIPTION
## Summary
- clip reflection boxes with RoundedCornerShape to match main icon shape
- import missing compose functions

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_687f8ce660488327956caa702cbe2936