### PR TITLE
Add overlay arrows for quick carousel navigation

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/CarouselArrow.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/CarouselArrow.kt
@@ -1,0 +1,50 @@
+package com.retrobreeze.ribbonlauncher
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.width
+
+enum class ArrowDirection { LEFT, RIGHT }
+
+@Composable
+fun CarouselArrow(
+    direction: ArrowDirection,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    width: Dp = 48.dp
+) {
+    val arrowModifier = modifier
+        .clickable(enabled = enabled, onClick = onClick)
+
+    Canvas(
+        modifier = arrowModifier
+            .fillMaxHeight()
+            .width(width)
+    ) {
+        val path = Path()
+        if (direction == ArrowDirection.LEFT) {
+            path.moveTo(size.width, 0f)
+            path.lineTo(0f, size.height / 2f)
+            path.lineTo(size.width, size.height)
+        } else {
+            path.moveTo(0f, 0f)
+            path.lineTo(size.width, size.height / 2f)
+            path.lineTo(0f, size.height)
+        }
+        path.close()
+        drawPath(
+            path = path,
+            color = Color.White.copy(alpha = if (enabled) 0.5f else 0.15f),
+            style = Fill
+        )
+    }
+}

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.unit.Density
 import com.retrobreeze.ribbonlauncher.model.GameEntry
+import com.retrobreeze.ribbonlauncher.ArrowDirection
+import com.retrobreeze.ribbonlauncher.CarouselArrow
 import kotlinx.coroutines.launch
 
 fun renderTextToBitmap(
@@ -184,6 +186,28 @@ fun GameCarousel(
             }
             }
         }
+        val canScrollLeft = pagerState.currentPage > 0
+        val canScrollRight = pagerState.currentPage < games.lastIndex
+
+        CarouselArrow(
+            direction = ArrowDirection.LEFT,
+            enabled = canScrollLeft,
+            onClick = {
+                val target = (pagerState.currentPage - 4).coerceAtLeast(0)
+                coroutineScope.launch { pagerState.animateScrollToPage(target) }
+            },
+            modifier = Modifier.align(Alignment.CenterStart)
+        )
+
+        CarouselArrow(
+            direction = ArrowDirection.RIGHT,
+            enabled = canScrollRight,
+            onClick = {
+                val target = (pagerState.currentPage + 4).coerceAtMost(games.lastIndex)
+                coroutineScope.launch { pagerState.animateScrollToPage(target) }
+            },
+            modifier = Modifier.align(Alignment.CenterEnd)
+        )
 
         labelBitmap?.let {
             Box(


### PR DESCRIPTION
## Summary
- create `CarouselArrow` composable to draw triangular navigation buttons
- overlay left/right arrows in `GameCarousel` and scroll four icons per tap

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687f9438b0888327bafce3d4aacd6c82