### PR TITLE
Add editable ribbon title

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
@@ -17,6 +17,7 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         private const val KEY_LAST_PLAYED_PREFIX = "lp_"
         private const val KEY_SELECTED_GAME = "selected_game"
         private const val KEY_ENABLED_PACKAGES = "enabled_packages"
+        private const val KEY_RIBBON_TITLE = "ribbon_title"
     }
 
     private val prefs = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -40,6 +41,9 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
     var selectedGamePackage by mutableStateOf<String?>(null)
         private set
 
+    var ribbonTitle by mutableStateOf("Games")
+        private set
+
     init {
         loadPreferences()
         loadInstalledGames()
@@ -52,6 +56,8 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         } catch (_: IllegalArgumentException) {
             SortMode.AZ
         }
+
+        ribbonTitle = prefs.getString(KEY_RIBBON_TITLE, "Games") ?: "Games"
 
         selectedGamePackage = prefs.getString(KEY_SELECTED_GAME, null)
 
@@ -158,6 +164,11 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         val now = System.currentTimeMillis()
         lastPlayed[game.packageName] = now
         prefs.edit().putLong(KEY_LAST_PLAYED_PREFIX + game.packageName, now).apply()
+    }
+
+    fun updateRibbonTitle(title: String) {
+        ribbonTitle = title
+        prefs.edit().putString(KEY_RIBBON_TITLE, title).apply()
     }
 
     fun refreshSort() {

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.foundation.pager.rememberPagerState
 import com.retrobreeze.ribbonlauncher.GameCarousel
 import com.retrobreeze.ribbonlauncher.SortButton
+import com.retrobreeze.ribbonlauncher.RibbonTitle
 import com.retrobreeze.ribbonlauncher.StatusTopBar
 import com.retrobreeze.ribbonlauncher.NavigationBottomBar
 import com.retrobreeze.ribbonlauncher.EditAppsDialog
@@ -111,15 +112,22 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                 onConfirm = { packages -> viewModel.updateEnabledPackages(packages) },
                 onDismiss = { showEditDialog = false }
             )
-            SortButton(
-                sortMode = sortMode,
-                onClick = {
-                    viewModel.cycleSortMode()
-                },
+            Row(
                 modifier = Modifier
                     .align(Alignment.TopStart)
-                    .padding(start = 8.dp, top = 36.dp)
-            )
+                    .padding(start = 8.dp, top = 36.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RibbonTitle(
+                    title = viewModel.ribbonTitle,
+                    onTitleChange = { viewModel.updateRibbonTitle(it) }
+                )
+                Spacer(Modifier.width(12.dp))
+                SortButton(
+                    sortMode = sortMode,
+                    onClick = { viewModel.cycleSortMode() }
+                )
+            }
             StatusTopBar(modifier = Modifier.align(Alignment.TopCenter))
             NavigationBottomBar(
                 modifier = Modifier.align(Alignment.BottomCenter),

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/RibbonTitle.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/RibbonTitle.kt
@@ -1,0 +1,64 @@
+package com.retrobreeze.ribbonlauncher
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RibbonTitle(
+    title: String,
+    onTitleChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var editing by remember { mutableStateOf(false) }
+    var localTitle by remember { mutableStateOf(TextFieldValue(title)) }
+
+    LaunchedEffect(title) {
+        if (!editing) {
+            localTitle = TextFieldValue(title)
+        }
+    }
+
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        if (editing) {
+            BasicTextField(
+                value = localTitle,
+                onValueChange = { localTitle = it },
+                textStyle = MaterialTheme.typography.headlineSmall.copy(color = MaterialTheme.colorScheme.onBackground),
+                singleLine = true,
+                modifier = Modifier
+                    .heightIn(min = 32.dp)
+                    .onFocusChanged { if (!it.isFocused) { editing = false; onTitleChange(localTitle.text) } }
+            )
+            Spacer(Modifier.width(4.dp))
+            IconButton(onClick = { editing = false; onTitleChange(localTitle.text) }) {
+                Icon(imageVector = Icons.Default.Check, contentDescription = "Done")
+            }
+        } else {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Spacer(Modifier.width(4.dp))
+            IconButton(onClick = { editing = true }) {
+                Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make ribbon title configurable and persisted
- expose `RibbonTitle` composable for inline editing
- place title and edit button next to the sort button

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6880c7f6c4cc8327b7e0b5e9f3526c2e