### PR TITLE
Remove unused buttons in bottom bar

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/NavigationBottomBar.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/NavigationBottomBar.kt
@@ -4,16 +4,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material3.ripple
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Apps
 import androidx.compose.runtime.Composable
@@ -29,8 +25,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 @Composable
 fun NavigationBottomBar(
     modifier: Modifier = Modifier,
-    onLeftClick: () -> Unit = {},
-    onCenterClick: () -> Unit = {},
     onRightClick: () -> Unit = {}
 ) {
     val isDark = isSystemInDarkTheme()
@@ -56,34 +50,9 @@ fun NavigationBottomBar(
     ) {
         Row(
             modifier = Modifier.fillMaxSize(),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.End
         ) {
-            Button(
-                onClick = onLeftClick,
-                modifier = Modifier
-                    .width(64.dp)
-                    .fillMaxHeight()
-                    .background(buttonGradient, RoundedCornerShape(0.dp)),
-                shape = RoundedCornerShape(0.dp),
-                contentPadding = PaddingValues(0.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
-            ) {
-                Text("Left")
-            }
-            Spacer(modifier = Modifier.width(4.dp))
-            Button(
-                onClick = onCenterClick,
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxHeight()
-                    .background(buttonGradient, RoundedCornerShape(0.dp)),
-                shape = RoundedCornerShape(0.dp),
-                contentPadding = PaddingValues(0.dp),
-                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent),
-            ) {
-                Text("Center")
-            }
-            Spacer(modifier = Modifier.width(4.dp))
             val interactionSource = remember { MutableInteractionSource() }
             Box(
                 modifier = Modifier


### PR DESCRIPTION
## Summary
- simplify `NavigationBottomBar` to only show the app drawer button

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6880fe7f8f708327897bb9aa7b3ed53a