### PR TITLE
Set white text color

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/ui/theme/Theme.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/ui/theme/Theme.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.graphics.Color
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
@@ -50,8 +51,16 @@ fun RibbonLauncherTheme(
         else -> LightColorScheme
     }
 
+    val whiteTextScheme = colorScheme.copy(
+        onPrimary = Color.White,
+        onSecondary = Color.White,
+        onTertiary = Color.White,
+        onBackground = Color.White,
+        onSurface = Color.White
+    )
+
     MaterialTheme(
-        colorScheme = colorScheme,
+        colorScheme = whiteTextScheme,
         typography = Typography,
         content = content
     )


### PR DESCRIPTION
## Summary
- enforce white text color by overriding color scheme

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881d8aad2e88327b5cf74e51c75e495