### PR TITLE
Add animated settings menu

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
@@ -151,6 +151,13 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         sortGames()
     }
 
+    fun updateSortMode(mode: SortMode) {
+        sortMode = mode
+        prefs.edit().putString(KEY_SORT_MODE, sortMode.name).apply()
+
+        sortGames()
+    }
+
     fun setSelectedGame(packageName: String?) {
         selectedGamePackage = packageName
         with(prefs.edit()) {

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -133,8 +133,8 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                 )
                 Spacer(Modifier.width(8.dp))
                 SettingsMenu(
-                    currentSortMode = sortMode,
-                    onSortSelected = { viewModel.updateSortMode(it) }
+                    sortMode = sortMode,
+                    onSortClick = { viewModel.cycleSortMode() }
                 )
             }
             StatusTopBar(modifier = Modifier.align(Alignment.TopCenter))

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -26,7 +26,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.background
 import androidx.compose.ui.graphics.Color
 import com.retrobreeze.ribbonlauncher.GameCarousel
-import com.retrobreeze.ribbonlauncher.SortButton
+import com.retrobreeze.ribbonlauncher.SettingsMenu
 import com.retrobreeze.ribbonlauncher.RibbonTitle
 import com.retrobreeze.ribbonlauncher.StatusTopBar
 import com.retrobreeze.ribbonlauncher.NavigationBottomBar
@@ -132,9 +132,9 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                         .background(Color.White.copy(alpha = 0.3f))
                 )
                 Spacer(Modifier.width(8.dp))
-                SortButton(
-                    sortMode = sortMode,
-                    onClick = { viewModel.cycleSortMode() }
+                SettingsMenu(
+                    currentSortMode = sortMode,
+                    onSortSelected = { viewModel.updateSortMode(it) }
                 )
             }
             StatusTopBar(modifier = Modifier.align(Alignment.TopCenter))

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
@@ -1,10 +1,13 @@
 package com.retrobreeze.ribbonlauncher
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.with
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -13,6 +16,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CropFree
 import androidx.compose.material.icons.filled.Delete
@@ -26,6 +30,7 @@ import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material.icons.filled.ZoomIn
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
@@ -35,14 +40,23 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 
 @Composable
+@OptIn(ExperimentalAnimationApi::class)
 fun SettingsMenu(
     sortMode: SortMode,
     onSortClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
+    var showSortLabel by remember { mutableStateOf(false) }
+
+    LaunchedEffect(sortMode) {
+        showSortLabel = true
+        delay(1000)
+        showSortLabel = false
+    }
 
     val divider: @Composable () -> Unit = {
         Box(
@@ -66,16 +80,32 @@ fun SettingsMenu(
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Spacer(Modifier.width(8.dp))
-                Icon(
-                    imageVector = Icons.Default.Sort,
-                    contentDescription = "Sort",
+                Box(
                     modifier = Modifier
-                        .size(24.dp)
-                        .clickable {
-                            onSortClick()
-                            expanded = false
+                        .height(24.dp)
+                        .widthIn(min = 24.dp)
+                        .clickable { onSortClick() },
+                    contentAlignment = Alignment.Center
+                ) {
+                    AnimatedContent(
+                        targetState = showSortLabel,
+                        transitionSpec = { fadeIn() with fadeOut() },
+                        label = "sortDisplay"
+                    ) { show ->
+                        if (show) {
+                            androidx.compose.material3.Text(
+                                text = sortMode.label,
+                                color = Color.White
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Default.Sort,
+                                contentDescription = "Sort",
+                                modifier = Modifier.size(24.dp)
+                            )
                         }
-                )
+                    }
+                }
                 Spacer(Modifier.width(8.dp))
                 Icon(
                     imageVector = Icons.Default.ZoomIn,

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
@@ -5,10 +5,25 @@ import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CropFree
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.LockOpen
+import androidx.compose.material.icons.filled.Photo
+import androidx.compose.material.icons.filled.Restore
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Sort
+import androidx.compose.material.icons.filled.TextFields
+import androidx.compose.material.icons.filled.ZoomIn
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -17,7 +32,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun SettingsMenu(
@@ -26,6 +43,15 @@ fun SettingsMenu(
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
+
+    val divider: @Composable () -> Unit = {
+        Box(
+            Modifier
+                .height(24.dp)
+                .width(1.dp)
+                .background(Color.White.copy(alpha = 0.3f))
+        )
+    }
 
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         Icon(
@@ -39,12 +65,58 @@ fun SettingsMenu(
             exit = shrinkHorizontally() + fadeOut()
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                SortButton(
-                    sortMode = sortMode,
-                    onClick = {
-                        onSortClick()
-                        expanded = false
-                    }
+                Spacer(Modifier.width(8.dp))
+                Icon(
+                    imageVector = Icons.Default.Sort,
+                    contentDescription = "Sort",
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clickable {
+                            onSortClick()
+                            expanded = false
+                        }
+                )
+                Spacer(Modifier.width(8.dp))
+                Icon(
+                    imageVector = Icons.Default.ZoomIn,
+                    contentDescription = "Icon Size",
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Icon(
+                    imageVector = Icons.Default.CropFree,
+                    contentDescription = "Selected Icon Size",
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Icon(
+                    imageVector = Icons.Default.TextFields,
+                    contentDescription = "Show Labels",
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Icon(
+                    imageVector = Icons.Default.Photo,
+                    contentDescription = "Wallpaper",
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                divider()
+                Spacer(Modifier.width(8.dp))
+                val locked = false
+                Icon(
+                    imageVector = if (locked) Icons.Default.Lock else Icons.Default.LockOpen,
+                    contentDescription = "Lock",
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                divider()
+                Spacer(Modifier.width(8.dp))
+                val erased = false
+                Icon(
+                    imageVector = if (erased) Icons.Default.Delete else Icons.Default.Restore,
+                    contentDescription = "Reset",
+                    modifier = Modifier.size(24.dp)
                 )
             }
         }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
@@ -1,0 +1,65 @@
+package com.retrobreeze.ribbonlauncher
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.SortByAlpha
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun SettingsMenu(
+    currentSortMode: SortMode,
+    onSortSelected: (SortMode) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        IconButton(onClick = { expanded = !expanded }) {
+            Icon(imageVector = Icons.Default.Settings, contentDescription = "Settings")
+        }
+        AnimatedVisibility(
+            visible = expanded,
+            enter = expandHorizontally() + fadeIn(),
+            exit = shrinkHorizontally() + fadeOut()
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                IconButton(onClick = { onSortSelected(SortMode.AZ); expanded = false }) {
+                    Icon(imageVector = Icons.Default.SortByAlpha, contentDescription = "Sort A-Z")
+                }
+                IconButton(onClick = { onSortSelected(SortMode.ZA); expanded = false }) {
+                    Icon(
+                        imageVector = Icons.Default.SortByAlpha,
+                        contentDescription = "Sort Z-A",
+                        modifier = Modifier.graphicsLayer(scaleY = -1f)
+                    )
+                }
+                IconButton(onClick = { onSortSelected(SortMode.RECENT); expanded = false }) {
+                    Icon(imageVector = Icons.Default.History, contentDescription = "Sort Recent")
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SettingsMenuPreview() {
+    SettingsMenu(currentSortMode = SortMode.AZ, onSortSelected = {})
+}

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
@@ -6,12 +6,10 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.SortByAlpha
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -19,40 +17,35 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
 fun SettingsMenu(
-    currentSortMode: SortMode,
-    onSortSelected: (SortMode) -> Unit,
+    sortMode: SortMode,
+    onSortClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
 
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
-        IconButton(onClick = { expanded = !expanded }) {
-            Icon(imageVector = Icons.Default.Settings, contentDescription = "Settings")
-        }
+        Icon(
+            imageVector = Icons.Default.Settings,
+            contentDescription = "Settings",
+            modifier = Modifier.clickable { expanded = !expanded }
+        )
         AnimatedVisibility(
             visible = expanded,
             enter = expandHorizontally() + fadeIn(),
             exit = shrinkHorizontally() + fadeOut()
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                IconButton(onClick = { onSortSelected(SortMode.AZ); expanded = false }) {
-                    Icon(imageVector = Icons.Default.SortByAlpha, contentDescription = "Sort A-Z")
-                }
-                IconButton(onClick = { onSortSelected(SortMode.ZA); expanded = false }) {
-                    Icon(
-                        imageVector = Icons.Default.SortByAlpha,
-                        contentDescription = "Sort Z-A",
-                        modifier = Modifier.graphicsLayer(scaleY = -1f)
-                    )
-                }
-                IconButton(onClick = { onSortSelected(SortMode.RECENT); expanded = false }) {
-                    Icon(imageVector = Icons.Default.History, contentDescription = "Sort Recent")
-                }
+                SortButton(
+                    sortMode = sortMode,
+                    onClick = {
+                        onSortClick()
+                        expanded = false
+                    }
+                )
             }
         }
     }
@@ -61,5 +54,5 @@ fun SettingsMenu(
 @Preview
 @Composable
 private fun SettingsMenuPreview() {
-    SettingsMenu(currentSortMode = SortMode.AZ, onSortSelected = {})
+    SettingsMenu(sortMode = SortMode.AZ, onSortClick = {})
 }


### PR DESCRIPTION
## Summary
- introduce `SettingsMenu` with animated inline icons
- update `MainActivity` to show settings gear instead of the text sort button
- add `updateSortMode` API to `LauncherViewModel`

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_6881e4e4077083279c291b1b71ae34de