### PR TITLE
Add icon size setting

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -75,12 +75,15 @@ fun GameCarousel(
     games: List<GameEntry>,
     pagerState: PagerState,
     selectedPackageName: String?,
+    iconScale: Float,
     onLaunch: (GameEntry) -> Unit,
     onEdit: () -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val itemSpacing = 12.dp
-    val itemSize = 150.dp
+    val baseItemSpacing = 12.dp
+    val baseItemSize = 150.dp
+    val itemSpacing by animateDpAsState(targetValue = baseItemSpacing * iconScale, label = "spacing")
+    val itemSize by animateDpAsState(targetValue = baseItemSize * iconScale, label = "itemSize")
     val selectedScale = 1.25f
     val maxPageWidth = itemSize * selectedScale
     val arrowHeight = itemSize * 0.5f
@@ -118,7 +121,8 @@ fun GameCarousel(
     }
 
     val screenWidthDp = LocalConfiguration.current.screenWidthDp.dp
-    val horizontalPadding = ((screenWidthDp - maxPageWidth) / 2).coerceAtLeast(0.dp)
+    val targetPadding = ((screenWidthDp - maxPageWidth) / 2).coerceAtLeast(0.dp)
+    val horizontalPadding by animateDpAsState(targetValue = targetPadding, label = "padding")
 
     val animatables = remember { mutableMapOf<String, Animatable<Float, AnimationVector1D>>() }
     var previousIndices by remember { mutableStateOf<Map<String, Int>>(emptyMap()) }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.*
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -82,13 +83,32 @@ fun GameCarousel(
     val coroutineScope = rememberCoroutineScope()
     val baseItemSpacing = 12.dp
     val baseItemSize = 150.dp
-    val itemSpacing by animateDpAsState(targetValue = baseItemSpacing * iconScale, label = "spacing")
-    val itemSize by animateDpAsState(targetValue = baseItemSize * iconScale, label = "itemSize")
+
+    var previousScale by remember { mutableStateOf(iconScale) }
+    var spacingTarget by remember { mutableStateOf(baseItemSpacing * iconScale) }
+
+    val itemSize by animateDpAsState(
+        targetValue = baseItemSize * iconScale,
+        animationSpec = tween(durationMillis = 300),
+        label = "itemSize"
+    )
+    val itemSpacing by animateDpAsState(
+        targetValue = spacingTarget,
+        animationSpec = tween(durationMillis = 300),
+        label = "spacing"
+    )
+
     var isResizing by remember { mutableStateOf(false) }
     LaunchedEffect(iconScale) {
-        isResizing = true
-        kotlinx.coroutines.delay(300)
-        isResizing = false
+        if (iconScale != previousScale) {
+            isResizing = true
+            spacingTarget = baseItemSpacing * previousScale
+            previousScale = iconScale
+            kotlinx.coroutines.delay(300)
+            spacingTarget = baseItemSpacing * iconScale
+            kotlinx.coroutines.delay(300)
+            isResizing = false
+        }
     }
     val selectedScale = 1.25f
     val maxPageWidth = itemSize * selectedScale

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -84,6 +84,12 @@ fun GameCarousel(
     val baseItemSize = 150.dp
     val itemSpacing by animateDpAsState(targetValue = baseItemSpacing * iconScale, label = "spacing")
     val itemSize by animateDpAsState(targetValue = baseItemSize * iconScale, label = "itemSize")
+    var isResizing by remember { mutableStateOf(false) }
+    LaunchedEffect(iconScale) {
+        isResizing = true
+        kotlinx.coroutines.delay(300)
+        isResizing = false
+    }
     val selectedScale = 1.25f
     val maxPageWidth = itemSize * selectedScale
     val arrowHeight = itemSize * 0.5f
@@ -220,7 +226,8 @@ fun GameCarousel(
                             ReflectiveGameIcon(
                                 icon = game.icon,
                                 contentDesc = game.displayName,
-                                iconSize = size
+                                iconSize = size,
+                                showReflection = !isResizing
                             )
                         }
                     }
@@ -280,7 +287,8 @@ fun GameCarousel(
 fun ReflectiveGameIcon(
     icon: Drawable,
     contentDesc: String,
-    iconSize: Dp
+    iconSize: Dp,
+    showReflection: Boolean = true
 ) {
     val bitmap = icon.toBitmap(width = 256, height = 256)
     val painter = BitmapPainter(bitmap.asImageBitmap())
@@ -300,36 +308,38 @@ fun ReflectiveGameIcon(
             contentScale = ContentScale.Crop
         )
 
-        Box(
-            modifier = Modifier
-                .height(iconSize * 0.25f)
-                .width(iconSize)
-                .clip(RoundedCornerShape(iconSize * 0.08f))
-                .drawWithCache {
-                    val gradient = Brush.verticalGradient(
-                        colors = listOf(Color.White.copy(alpha = 0.5f), Color.Transparent),
-                        startY = 0f,
-                        endY = size.height
-                    )
-                    onDrawWithContent {
-                        with(drawContext.canvas) {
-                            saveLayer(bounds = size.toRect(), paint = Paint())
-                            drawContent()
-                            drawRect(gradient, blendMode = BlendMode.DstIn)
-                            restore()
+        if (showReflection) {
+            Box(
+                modifier = Modifier
+                    .height(iconSize * 0.25f)
+                    .width(iconSize)
+                    .clip(RoundedCornerShape(iconSize * 0.08f))
+                    .drawWithCache {
+                        val gradient = Brush.verticalGradient(
+                            colors = listOf(Color.White.copy(alpha = 0.5f), Color.Transparent),
+                            startY = 0f,
+                            endY = size.height
+                        )
+                        onDrawWithContent {
+                            with(drawContext.canvas) {
+                                saveLayer(bounds = size.toRect(), paint = Paint())
+                                drawContent()
+                                drawRect(gradient, blendMode = BlendMode.DstIn)
+                                restore()
+                            }
                         }
                     }
-                }
-        ) {
-            Image(
-                painter = painter,
-                contentDescription = null,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .graphicsLayer { scaleY = -1f },
-                contentScale = ContentScale.Crop,
-                alignment = Alignment.BottomCenter
-            )
+            ) {
+                Image(
+                    painter = painter,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer { scaleY = -1f },
+                    contentScale = ContentScale.Crop,
+                    alignment = Alignment.BottomCenter
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -187,7 +187,7 @@ fun GameCarousel(
                             modifier = Modifier
                                 .height(size + (size * 0.25f))
                                 .width(size)
-                                .clip(RoundedCornerShape(12.dp))
+                                .clip(RoundedCornerShape(size * 0.08f))
                                 .background(Color.Gray.copy(alpha = 0.3f))
                                 .clickable {
                                     if (isSelected) {
@@ -296,7 +296,7 @@ fun ReflectiveGameIcon(
             contentDescription = contentDesc,
             modifier = Modifier
                 .size(iconSize)
-                .clip(RoundedCornerShape(12.dp)),
+                .clip(RoundedCornerShape(iconSize * 0.08f)),
             contentScale = ContentScale.Crop
         )
 
@@ -304,7 +304,7 @@ fun ReflectiveGameIcon(
             modifier = Modifier
                 .height(iconSize * 0.25f)
                 .width(iconSize)
-                .clip(RoundedCornerShape(12.dp))
+                .clip(RoundedCornerShape(iconSize * 0.08f))
                 .drawWithCache {
                     val gradient = Brush.verticalGradient(
                         colors = listOf(Color.White.copy(alpha = 0.5f), Color.Transparent),

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/IconSizeOption.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/IconSizeOption.kt
@@ -1,0 +1,13 @@
+package com.retrobreeze.ribbonlauncher
+
+enum class IconSizeOption(val multiplier: Float) {
+    FULL(1f),
+    THREE_QUARTERS(0.75f),
+    HALF(0.5f);
+
+    fun next(): IconSizeOption = when (this) {
+        FULL -> THREE_QUARTERS
+        THREE_QUARTERS -> HALF
+        HALF -> FULL
+    }
+}

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
@@ -18,6 +18,7 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         private const val KEY_SELECTED_GAME = "selected_game"
         private const val KEY_ENABLED_PACKAGES = "enabled_packages"
         private const val KEY_RIBBON_TITLE = "ribbon_title"
+        private const val KEY_ICON_SIZE = "icon_size"
     }
 
     private val prefs = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -44,6 +45,9 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
     var ribbonTitle by mutableStateOf("Games")
         private set
 
+    var iconSizeOption by mutableStateOf(IconSizeOption.FULL)
+        private set
+
     init {
         loadPreferences()
         loadInstalledGames()
@@ -60,6 +64,12 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         ribbonTitle = prefs.getString(KEY_RIBBON_TITLE, "Games") ?: "Games"
 
         selectedGamePackage = prefs.getString(KEY_SELECTED_GAME, null)
+
+        iconSizeOption = try {
+            IconSizeOption.valueOf(prefs.getString(KEY_ICON_SIZE, IconSizeOption.FULL.name)!!)
+        } catch (_: IllegalArgumentException) {
+            IconSizeOption.FULL
+        }
 
         enabledPackages = if (prefs.contains(KEY_ENABLED_PACKAGES)) {
             prefs.getStringSet(KEY_ENABLED_PACKAGES, emptySet())?.toSet() ?: emptySet()
@@ -149,6 +159,11 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         prefs.edit().putString(KEY_SORT_MODE, sortMode.name).apply()
 
         sortGames()
+    }
+
+    fun cycleIconSize() {
+        iconSizeOption = iconSizeOption.next()
+        prefs.edit().putString(KEY_ICON_SIZE, iconSizeOption.name).apply()
     }
 
     fun updateSortMode(mode: SortMode) {

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -87,6 +87,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     games = games,
                     pagerState = pagerState,
                     selectedPackageName = viewModel.selectedGamePackage,
+                    iconScale = viewModel.iconSizeOption.multiplier,
                     onLaunch = { game ->
                         val intent = context.packageManager.getLaunchIntentForPackage(game.packageName)
                         if (intent != null) {
@@ -134,7 +135,8 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                 Spacer(Modifier.width(8.dp))
                 SettingsMenu(
                     sortMode = sortMode,
-                    onSortClick = { viewModel.cycleSortMode() }
+                    onSortClick = { viewModel.cycleSortMode() },
+                    onIconSizeClick = { viewModel.cycleIconSize() }
                 )
             }
             StatusTopBar(modifier = Modifier.align(Alignment.TopCenter))

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.delay
 fun SettingsMenu(
     sortMode: SortMode,
     onSortClick: () -> Unit,
+    onIconSizeClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -110,7 +111,9 @@ fun SettingsMenu(
                 Icon(
                     imageVector = Icons.Default.ZoomIn,
                     contentDescription = "Icon Size",
-                    modifier = Modifier.size(24.dp)
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clickable { onIconSizeClick() }
                 )
                 Spacer(Modifier.width(8.dp))
                 Icon(
@@ -156,5 +159,5 @@ fun SettingsMenu(
 @Preview
 @Composable
 private fun SettingsMenuPreview() {
-    SettingsMenu(sortMode = SortMode.AZ, onSortClick = {})
+    SettingsMenu(sortMode = SortMode.AZ, onSortClick = {}, onIconSizeClick = {})
 }


### PR DESCRIPTION
## Summary
- add `IconSizeOption` enum for three size levels
- persist icon size in `LauncherViewModel`
- expose `cycleIconSize` and trigger from Settings menu
- let `GameCarousel` animate item size and spacing

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6881fb74e9f48327b4208c32793349fa