### PR TITLE
Add selected icon resize setting

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -77,6 +77,7 @@ fun GameCarousel(
     pagerState: PagerState,
     selectedPackageName: String?,
     iconScale: Float,
+    selectedIconScale: Float,
     onLaunch: (GameEntry) -> Unit,
     onEdit: () -> Unit
 ) {
@@ -91,6 +92,11 @@ fun GameCarousel(
         targetValue = baseItemSize * iconScale,
         animationSpec = tween(durationMillis = 300),
         label = "itemSize"
+    )
+    val selectedItemSize by animateDpAsState(
+        targetValue = baseItemSize * selectedIconScale,
+        animationSpec = tween(durationMillis = 300),
+        label = "selectedItemSize"
     )
     val itemSpacing by animateDpAsState(
         targetValue = spacingTarget,
@@ -111,8 +117,8 @@ fun GameCarousel(
         }
     }
     val selectedScale = 1.25f
-    val maxPageWidth = itemSize * selectedScale
-    val arrowHeight = itemSize * 0.5f
+    val maxPageWidth = maxOf(itemSize, selectedItemSize * selectedScale)
+    val arrowHeight = maxOf(itemSize, selectedItemSize) * 0.5f
     val arrowWidth = arrowHeight / 2
 
     val density = LocalDensity.current
@@ -196,7 +202,7 @@ fun GameCarousel(
                 val isEditPage = page == games.size
                 val isSelected = pagerState.currentPage == page
                 val size by animateDpAsState(
-                    targetValue = if (isSelected) itemSize * selectedScale else itemSize,
+                    targetValue = if (isSelected) selectedItemSize * selectedScale else itemSize,
                     label = "SizeAnimation"
                 )
 

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
@@ -19,6 +19,7 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         private const val KEY_ENABLED_PACKAGES = "enabled_packages"
         private const val KEY_RIBBON_TITLE = "ribbon_title"
         private const val KEY_ICON_SIZE = "icon_size"
+        private const val KEY_SELECTED_ICON_SIZE = "selected_icon_size"
     }
 
     private val prefs = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -48,6 +49,9 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
     var iconSizeOption by mutableStateOf(IconSizeOption.FULL)
         private set
 
+    var selectedIconSizeOption by mutableStateOf(IconSizeOption.FULL)
+        private set
+
     init {
         loadPreferences()
         loadInstalledGames()
@@ -67,6 +71,12 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
 
         iconSizeOption = try {
             IconSizeOption.valueOf(prefs.getString(KEY_ICON_SIZE, IconSizeOption.FULL.name)!!)
+        } catch (_: IllegalArgumentException) {
+            IconSizeOption.FULL
+        }
+
+        selectedIconSizeOption = try {
+            IconSizeOption.valueOf(prefs.getString(KEY_SELECTED_ICON_SIZE, IconSizeOption.FULL.name)!!)
         } catch (_: IllegalArgumentException) {
             IconSizeOption.FULL
         }
@@ -164,6 +174,11 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
     fun cycleIconSize() {
         iconSizeOption = iconSizeOption.next()
         prefs.edit().putString(KEY_ICON_SIZE, iconSizeOption.name).apply()
+    }
+
+    fun cycleSelectedIconSize() {
+        selectedIconSizeOption = selectedIconSizeOption.next()
+        prefs.edit().putString(KEY_SELECTED_ICON_SIZE, selectedIconSizeOption.name).apply()
     }
 
     fun updateSortMode(mode: SortMode) {

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -88,6 +88,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     pagerState = pagerState,
                     selectedPackageName = viewModel.selectedGamePackage,
                     iconScale = viewModel.iconSizeOption.multiplier,
+                    selectedIconScale = viewModel.selectedIconSizeOption.multiplier,
                     onLaunch = { game ->
                         val intent = context.packageManager.getLaunchIntentForPackage(game.packageName)
                         if (intent != null) {
@@ -136,7 +137,8 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                 SettingsMenu(
                     sortMode = sortMode,
                     onSortClick = { viewModel.cycleSortMode() },
-                    onIconSizeClick = { viewModel.cycleIconSize() }
+                    onIconSizeClick = { viewModel.cycleIconSize() },
+                    onSelectedIconSizeClick = { viewModel.cycleSelectedIconSize() }
                 )
             }
             StatusTopBar(modifier = Modifier.align(Alignment.TopCenter))

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
@@ -48,6 +48,7 @@ fun SettingsMenu(
     sortMode: SortMode,
     onSortClick: () -> Unit,
     onIconSizeClick: () -> Unit,
+    onSelectedIconSizeClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -119,7 +120,9 @@ fun SettingsMenu(
                 Icon(
                     imageVector = Icons.Default.CropFree,
                     contentDescription = "Selected Icon Size",
-                    modifier = Modifier.size(24.dp)
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clickable { onSelectedIconSizeClick() }
                 )
                 Spacer(Modifier.width(8.dp))
                 Icon(
@@ -159,5 +162,10 @@ fun SettingsMenu(
 @Preview
 @Composable
 private fun SettingsMenuPreview() {
-    SettingsMenu(sortMode = SortMode.AZ, onSortClick = {}, onIconSizeClick = {})
+    SettingsMenu(
+        sortMode = SortMode.AZ,
+        onSortClick = {},
+        onIconSizeClick = {},
+        onSelectedIconSizeClick = {}
+    )
 }


### PR DESCRIPTION
## Summary
- allow adjusting central icon size independently
- handle new setting in `GameCarousel` layout logic
- support selected icon resize in `LauncherViewModel`
- wire SettingsMenu button to cycle this size

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6882151715388327b2a71a9e13f32d15