### PR TITLE
Smooth reflection fading during resize

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -354,38 +354,43 @@ fun ReflectiveGameIcon(
             contentScale = ContentScale.Crop
         )
 
-        if (showReflection) {
-            Box(
-                modifier = Modifier
-                    .height(iconSize * 0.25f)
-                    .width(iconSize)
-                    .clip(RoundedCornerShape(iconSize * 0.08f))
-                    .drawWithCache {
-                        val gradient = Brush.verticalGradient(
-                            colors = listOf(Color.White.copy(alpha = 0.5f), Color.Transparent),
-                            startY = 0f,
-                            endY = size.height
-                        )
-                        onDrawWithContent {
-                            with(drawContext.canvas) {
-                                saveLayer(bounds = size.toRect(), paint = Paint())
-                                drawContent()
-                                drawRect(gradient, blendMode = BlendMode.DstIn)
-                                restore()
-                            }
+        val reflectionAlpha by animateFloatAsState(
+            targetValue = if (showReflection) 1f else 0f,
+            animationSpec = tween(durationMillis = 150),
+            label = "reflectionAlpha"
+        )
+
+        Box(
+            modifier = Modifier
+                .height(iconSize * 0.25f)
+                .width(iconSize)
+                .alpha(reflectionAlpha)
+                .clip(RoundedCornerShape(iconSize * 0.08f))
+                .drawWithCache {
+                    val gradient = Brush.verticalGradient(
+                        colors = listOf(Color.White.copy(alpha = 0.5f), Color.Transparent),
+                        startY = 0f,
+                        endY = size.height
+                    )
+                    onDrawWithContent {
+                        with(drawContext.canvas) {
+                            saveLayer(bounds = size.toRect(), paint = Paint())
+                            drawContent()
+                            drawRect(gradient, blendMode = BlendMode.DstIn)
+                            restore()
                         }
                     }
-            ) {
-                Image(
-                    painter = painter,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .graphicsLayer { scaleY = -1f },
-                    contentScale = ContentScale.Crop,
-                    alignment = Alignment.BottomCenter
-                )
-            }
+                }
+        ) {
+            Image(
+                painter = painter,
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer { scaleY = -1f },
+                contentScale = ContentScale.Crop,
+                alignment = Alignment.BottomCenter
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- update `ReflectiveGameIcon` to animate reflection alpha

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68823a53dce4832781c355ff71eee8d5