### PR TITLE
Fix text contrast in modals

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/AppDrawerOverlay.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/AppDrawerOverlay.kt
@@ -17,10 +17,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 import com.retrobreeze.ribbonlauncher.model.GameEntry
+import com.retrobreeze.ribbonlauncher.util.contrastingColor
 
 @Composable
 fun AppDrawerOverlay(
@@ -46,11 +48,15 @@ fun AppDrawerOverlay(
                     interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
                 )
         ) {
+            val surfaceColor = MaterialTheme.colorScheme.surface
+            val contentColor = surfaceColor.contrastingColor()
             Surface(
                 modifier = Modifier
                     .fillMaxHeight()
                     .width(480.dp)
-                    .align(Alignment.CenterEnd)
+                    .align(Alignment.CenterEnd),
+                color = surfaceColor,
+                contentColor = contentColor
             ) {
                 LazyVerticalGrid(
                     columns = GridCells.Fixed(5),

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/EditAppsDialog.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/EditAppsDialog.kt
@@ -16,11 +16,13 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import coil.compose.rememberAsyncImagePainter
 import com.retrobreeze.ribbonlauncher.model.GameEntry
+import com.retrobreeze.ribbonlauncher.util.contrastingColor
 
 @Composable
 fun EditAppsDialog(
@@ -55,11 +57,15 @@ fun EditAppsDialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
+        val surfaceColor = MaterialTheme.colorScheme.surface
+        val contentColor = surfaceColor.contrastingColor()
         Surface(
             modifier = Modifier
                 .padding(WindowInsets.systemBars.asPaddingValues())
                 .widthIn(max = 400.dp),
-            shape = MaterialTheme.shapes.medium
+            shape = MaterialTheme.shapes.medium,
+            color = surfaceColor,
+            contentColor = contentColor
         ) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Row(

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/WallpaperThemeDialog.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/WallpaperThemeDialog.kt
@@ -11,11 +11,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.retrobreeze.ribbonlauncher.ui.background.WallpaperTheme
+import com.retrobreeze.ribbonlauncher.util.contrastingColor
 
 @Composable
 fun WallpaperThemeDialog(
@@ -30,10 +32,14 @@ fun WallpaperThemeDialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
+        val surfaceColor = MaterialTheme.colorScheme.surface
+        val contentColor = surfaceColor.contrastingColor()
         Surface(
             modifier = Modifier
                 .padding(16.dp)
-                .widthIn(max = 400.dp)
+                .widthIn(max = 400.dp),
+            color = surfaceColor,
+            contentColor = contentColor
         ) {
             LazyColumn(modifier = Modifier.fillMaxWidth()) {
                 items(WallpaperTheme.values()) { theme ->
@@ -57,7 +63,7 @@ fun WallpaperThemeDialog(
                         Text(
                             text = theme.label,
                             style = MaterialTheme.typography.bodyMedium,
-                            color = if (theme == current) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+                            color = if (theme == current) MaterialTheme.colorScheme.primary else contentColor
                         )
                     }
                 }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/util/ColorUtils.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/util/ColorUtils.kt
@@ -1,0 +1,6 @@
+package com.retrobreeze.ribbonlauncher.util
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+
+fun Color.contrastingColor(): Color = if (luminance() < 0.5f) Color.White else Color.Black


### PR DESCRIPTION
## Summary
- compute text color based on background luminance
- update drawer and dialogs to use contrasting text

## Testing
- `./gradlew test --stacktrace` *(fails: Install Android SDK Platform 36)*

------
https://chatgpt.com/codex/tasks/task_e_68827ac47d348327a75fc33a4a680eb0