### PR TITLE
Implement ribbon lock

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -78,6 +78,7 @@ fun GameCarousel(
     selectedPackageName: String?,
     iconScale: Float,
     showLabels: Boolean = true,
+    showEditButton: Boolean = true,
     onLaunch: (GameEntry) -> Unit,
     onEdit: () -> Unit
 ) {
@@ -119,7 +120,7 @@ fun GameCarousel(
     val density = LocalDensity.current
     var currentText by remember {
         mutableStateOf(
-            if (pagerState.currentPage == games.size) "Edit" else games.getOrNull(pagerState.currentPage)?.displayName.orEmpty()
+            if (showEditButton && pagerState.currentPage == games.size) "Edit" else games.getOrNull(pagerState.currentPage)?.displayName.orEmpty()
         )
     }
     var labelBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
@@ -131,7 +132,7 @@ fun GameCarousel(
     )
 
     LaunchedEffect(pagerState.currentPage) {
-        val newText = if (pagerState.currentPage == games.size) {
+        val newText = if (showEditButton && pagerState.currentPage == games.size) {
             "Edit"
         } else {
             games.getOrNull(pagerState.currentPage)?.displayName.orEmpty()
@@ -164,7 +165,7 @@ fun GameCarousel(
 
     val animatables = remember { mutableMapOf<String, Animatable<Float, AnimationVector1D>>() }
     var previousIndices by remember { mutableStateOf<Map<String, Int>>(emptyMap()) }
-    val totalPages = games.size + 1
+    val totalPages = games.size + if (showEditButton) 1 else 0
 
     LaunchedEffect(games) {
         val itemWidthPx = with(density) { (maxPageWidth + itemSpacing).toPx() }
@@ -205,7 +206,7 @@ fun GameCarousel(
                 ),
                 key = { index -> if (index < games.size) games[index].packageName else "edit_button" }
             ) { page ->
-                val isEditPage = page == games.size
+                val isEditPage = showEditButton && page == games.size
                 val isSelected = pagerState.currentPage == page
                 val scale by animateFloatAsState(
                     targetValue = if (isSelected) selectedScale else 1f,

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
@@ -22,6 +22,7 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         private const val KEY_ICON_SIZE = "icon_size"
         private const val KEY_SHOW_LABELS = "show_labels"
         private const val KEY_WALLPAPER_THEME = "wallpaper_theme"
+        private const val KEY_SETTINGS_LOCKED = "settings_locked"
     }
 
     private val prefs = app.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -57,6 +58,9 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
     var wallpaperTheme by mutableStateOf(WallpaperTheme.XMB_CLASSIC_BLUE)
         private set
 
+    var settingsLocked by mutableStateOf(false)
+        private set
+
     init {
         loadPreferences()
         loadInstalledGames()
@@ -87,6 +91,8 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         }
 
         showLabels = prefs.getBoolean(KEY_SHOW_LABELS, true)
+
+        settingsLocked = prefs.getBoolean(KEY_SETTINGS_LOCKED, false)
 
         enabledPackages = if (prefs.contains(KEY_ENABLED_PACKAGES)) {
             prefs.getStringSet(KEY_ENABLED_PACKAGES, emptySet())?.toSet() ?: emptySet()
@@ -218,6 +224,11 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
     fun updateWallpaperTheme(theme: WallpaperTheme) {
         wallpaperTheme = theme
         prefs.edit().putString(KEY_WALLPAPER_THEME, theme.name).apply()
+    }
+
+    fun toggleSettingsLocked() {
+        settingsLocked = !settingsLocked
+        prefs.edit().putBoolean(KEY_SETTINGS_LOCKED, settingsLocked).apply()
     }
 
     fun refreshSort() {

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -69,7 +69,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
     var showDrawer by remember { mutableStateOf(false) }
     var showEditDialog by remember { mutableStateOf(false) }
     var showWallpaperDialog by remember { mutableStateOf(false) }
-    val pagerState = rememberPagerState(initialPage = 0) { games.size + 1 }
+    val pagerState = rememberPagerState(initialPage = 0) { games.size + if (!viewModel.settingsLocked) 1 else 0 }
 
     LaunchedEffect(pagerState.currentPage, games) {
         val pkg = games.getOrNull(pagerState.currentPage)?.packageName
@@ -94,6 +94,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     selectedPackageName = viewModel.selectedGamePackage,
                     iconScale = viewModel.iconSizeOption.multiplier,
                     showLabels = viewModel.showLabels,
+                    showEditButton = !viewModel.settingsLocked,
                     onLaunch = { game ->
                         val intent = context.packageManager.getLaunchIntentForPackage(game.packageName)
                         if (intent != null) {
@@ -135,7 +136,8 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
             ) {
                 RibbonTitle(
                     title = viewModel.ribbonTitle,
-                    onTitleChange = { viewModel.updateRibbonTitle(it) }
+                    onTitleChange = { viewModel.updateRibbonTitle(it) },
+                    enabled = !viewModel.settingsLocked
                 )
                 Spacer(Modifier.width(8.dp))
                 Box(
@@ -151,7 +153,9 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     onIconSizeClick = { viewModel.cycleIconSize() },
                     showLabels = viewModel.showLabels,
                     onToggleLabels = { viewModel.toggleShowLabels() },
-                    onWallpaperClick = { showWallpaperDialog = true }
+                    onWallpaperClick = { showWallpaperDialog = true },
+                    locked = viewModel.settingsLocked,
+                    onLockToggle = { viewModel.toggleSettingsLocked() }
                 )
             }
             StatusTopBar(modifier = Modifier.align(Alignment.TopCenter))

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/RibbonTitle.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/RibbonTitle.kt
@@ -36,6 +36,7 @@ private const val MAX_TITLE_LENGTH = 50
 fun RibbonTitle(
     title: String,
     onTitleChange: (String) -> Unit,
+    enabled: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     var editing by remember { mutableStateOf(false) }
@@ -48,6 +49,12 @@ fun RibbonTitle(
     LaunchedEffect(title) {
         if (!editing) {
             localTitle = TextFieldValue(title)
+        }
+    }
+
+    LaunchedEffect(enabled) {
+        if (!enabled) {
+            editing = false
         }
     }
 
@@ -105,7 +112,7 @@ fun RibbonTitle(
                 text = title,
                 style = MaterialTheme.typography.headlineSmall,
                 color = Color.White,
-                modifier = Modifier.clickable {
+                modifier = Modifier.clickable(enabled = enabled) {
                     localTitle = TextFieldValue(title, TextRange(0, title.length))
                     editing = true
                 }
@@ -118,5 +125,5 @@ fun RibbonTitle(
 @Preview
 @Composable
 private fun RibbonTitlePreview() {
-    RibbonTitle(title = "Games", onTitleChange = {})
+    RibbonTitle(title = "Games", onTitleChange = {}, enabled = true)
 }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.Photo
@@ -37,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -51,6 +51,8 @@ fun SettingsMenu(
     showLabels: Boolean,
     onToggleLabels: () -> Unit,
     onWallpaperClick: () -> Unit,
+    locked: Boolean,
+    onLockToggle: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -75,7 +77,9 @@ fun SettingsMenu(
         Icon(
             imageVector = Icons.Default.Settings,
             contentDescription = "Settings",
-            modifier = Modifier.clickable { expanded = !expanded }
+            modifier = Modifier
+                .alpha(if (locked) 0.3f else 1f)
+                .clickable { expanded = !expanded }
         )
         AnimatedVisibility(
             visible = expanded,
@@ -88,7 +92,8 @@ fun SettingsMenu(
                     modifier = Modifier
                         .height(24.dp)
                         .widthIn(min = 24.dp)
-                        .clickable { onSortClick() },
+                        .alpha(if (locked) 0.3f else 1f)
+                        .clickable(enabled = !locked) { onSortClick() },
                     contentAlignment = Alignment.Center
                 ) {
                     AnimatedContent(
@@ -116,7 +121,8 @@ fun SettingsMenu(
                     contentDescription = "Icon Size",
                     modifier = Modifier
                         .size(24.dp)
-                        .clickable { onIconSizeClick() }
+                        .alpha(if (locked) 0.3f else 1f)
+                        .clickable(enabled = !locked) { onIconSizeClick() }
                 )
                 Spacer(Modifier.width(8.dp))
                 Icon(
@@ -124,7 +130,8 @@ fun SettingsMenu(
                     contentDescription = "Toggle Labels",
                     modifier = Modifier
                         .size(24.dp)
-                        .clickable { onToggleLabels() }
+                        .alpha(if (locked) 0.3f else 1f)
+                        .clickable(enabled = !locked) { onToggleLabels() }
                 )
                 Spacer(Modifier.width(8.dp))
                 Icon(
@@ -132,25 +139,32 @@ fun SettingsMenu(
                     contentDescription = "Wallpaper",
                     modifier = Modifier
                         .size(24.dp)
-                        .clickable { onWallpaperClick() }
+                        .alpha(if (locked) 0.3f else 1f)
+                        .clickable(enabled = !locked) { onWallpaperClick() }
                 )
                 Spacer(Modifier.width(8.dp))
                 divider()
                 Spacer(Modifier.width(8.dp))
-                val locked = false
                 Icon(
                     imageVector = if (locked) Icons.Default.Lock else Icons.Default.LockOpen,
                     contentDescription = "Lock",
-                    modifier = Modifier.size(24.dp)
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clickable {
+                            onLockToggle()
+                            if (!locked) expanded = false
+                        }
                 )
                 Spacer(Modifier.width(8.dp))
                 divider()
                 Spacer(Modifier.width(8.dp))
-                val erased = false
                 Icon(
-                    imageVector = if (erased) Icons.Default.Delete else Icons.Default.Restore,
+                    imageVector = Icons.Default.Restore,
                     contentDescription = "Reset",
-                    modifier = Modifier.size(24.dp)
+                    modifier = Modifier
+                        .size(24.dp)
+                        .alpha(if (locked) 0.3f else 1f)
+                        .clickable(enabled = !locked) { }
                 )
             }
         }
@@ -166,6 +180,8 @@ private fun SettingsMenuPreview() {
         onIconSizeClick = {},
         showLabels = true,
         onToggleLabels = {},
-        onWallpaperClick = {}
+        onWallpaperClick = {},
+        locked = false,
+        onLockToggle = {}
     )
 }


### PR DESCRIPTION
## Summary
- enable settings lock through view model state
- disable settings menu buttons when locked
- prevent editing ribbon title when locked
- hide edit page in carousel when locked
- expose lock toggle in UI

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_688280cd01a88327a7f753878765cf8b