### PR TITLE
Implement ribbon reset feature

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
@@ -231,6 +231,13 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         prefs.edit().putBoolean(KEY_SETTINGS_LOCKED, settingsLocked).apply()
     }
 
+    fun resetLauncher() {
+        prefs.edit().clear().apply()
+        lastPlayed.clear()
+        loadPreferences()
+        sortGames()
+    }
+
     fun refreshSort() {
         sortGames()
     }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -32,6 +32,7 @@ import com.retrobreeze.ribbonlauncher.StatusTopBar
 import com.retrobreeze.ribbonlauncher.NavigationBottomBar
 import com.retrobreeze.ribbonlauncher.EditAppsDialog
 import com.retrobreeze.ribbonlauncher.WallpaperThemeDialog
+import com.retrobreeze.ribbonlauncher.ResetConfirmationDialog
 import com.retrobreeze.ribbonlauncher.ui.background.AnimatedBackground
 import com.retrobreeze.ribbonlauncher.ui.theme.RibbonLauncherTheme
 
@@ -69,6 +70,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
     var showDrawer by remember { mutableStateOf(false) }
     var showEditDialog by remember { mutableStateOf(false) }
     var showWallpaperDialog by remember { mutableStateOf(false) }
+    var showResetDialog by remember { mutableStateOf(false) }
     val pagerState = rememberPagerState(initialPage = 0) { games.size + if (!viewModel.settingsLocked) 1 else 0 }
 
     LaunchedEffect(pagerState.currentPage, games) {
@@ -128,6 +130,14 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                 onSelect = { viewModel.updateWallpaperTheme(it) },
                 onDismiss = { showWallpaperDialog = false }
             )
+            ResetConfirmationDialog(
+                show = showResetDialog,
+                onConfirm = {
+                    viewModel.resetLauncher()
+                    showResetDialog = false
+                },
+                onDismiss = { showResetDialog = false }
+            )
             Row(
                 modifier = Modifier
                     .align(Alignment.TopStart)
@@ -155,7 +165,8 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     onToggleLabels = { viewModel.toggleShowLabels() },
                     onWallpaperClick = { showWallpaperDialog = true },
                     locked = viewModel.settingsLocked,
-                    onLockToggle = { viewModel.toggleSettingsLocked() }
+                    onLockToggle = { viewModel.toggleSettingsLocked() },
+                    onResetClick = { showResetDialog = true }
                 )
             }
             StatusTopBar(modifier = Modifier.align(Alignment.TopCenter))

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/ResetConfirmationDialog.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/ResetConfirmationDialog.kt
@@ -1,0 +1,38 @@
+package com.retrobreeze.ribbonlauncher
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun ResetConfirmationDialog(
+    show: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    if (!show) return
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Reset Ribbon") },
+        text = { Text("This will restore the ribbon to its default state and remove all customizations. Continue?") },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                    contentColor = MaterialTheme.colorScheme.onError
+                )
+            ) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            OutlinedButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/SettingsMenu.kt
@@ -53,6 +53,7 @@ fun SettingsMenu(
     onWallpaperClick: () -> Unit,
     locked: Boolean,
     onLockToggle: () -> Unit,
+    onResetClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -164,7 +165,7 @@ fun SettingsMenu(
                     modifier = Modifier
                         .size(24.dp)
                         .alpha(if (locked) 0.3f else 1f)
-                        .clickable(enabled = !locked) { }
+                        .clickable(enabled = !locked) { onResetClick() }
                 )
             }
         }
@@ -182,6 +183,7 @@ private fun SettingsMenuPreview() {
         onToggleLabels = {},
         onWallpaperClick = {},
         locked = false,
-        onLockToggle = {}
+        onLockToggle = {},
+        onResetClick = {}
     )
 }


### PR DESCRIPTION
## Summary
- add reset confirmation dialog
- wire up reset button in SettingsMenu
- enable clearing preferences via `resetLauncher`

## Testing
- `./gradlew assembleDebug -q` *(fails: Kotlin daemon terminated)*

------
https://chatgpt.com/codex/tasks/task_e_688287c05eb88327a889a37155056e01