### PR TITLE
Add parallax wallpaper motion

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/ui/background/AnimatedBackground.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/ui/background/AnimatedBackground.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -17,12 +18,14 @@ import androidx.compose.ui.graphics.drawscope.Fill
 import com.retrobreeze.ribbonlauncher.ui.background.WallpaperTheme
 import kotlin.math.PI
 import kotlin.math.sin
+import com.retrobreeze.ribbonlauncher.util.rememberParallaxOffset
 
 @Composable
 fun AnimatedBackground(
     theme: WallpaperTheme,
     modifier: Modifier = Modifier
 ) {
+    val parallaxOffset = rememberParallaxOffset()
     val animatedStart by androidx.compose.animation.animateColorAsState(
         targetValue = theme.startColor,
         animationSpec = tween(durationMillis = 600),
@@ -53,7 +56,12 @@ fun AnimatedBackground(
         ), label = "wave2"
     )
 
-    androidx.compose.foundation.Canvas(modifier = modifier) {
+    androidx.compose.foundation.Canvas(
+        modifier = modifier.graphicsLayer {
+            translationX = parallaxOffset.value.x
+            translationY = parallaxOffset.value.y
+        }
+    ) {
         drawRect(
             brush = Brush.radialGradient(
                 colors = gradientColors,

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/util/MotionUtils.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/util/MotionUtils.kt
@@ -1,0 +1,53 @@
+package com.retrobreeze.ribbonlauncher.util
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.State
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+
+@Composable
+fun rememberParallaxOffset(maxOffsetDp: Float = 16f): State<Offset> {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val sensorManager = remember { context.getSystemService(Context.SENSOR_SERVICE) as SensorManager }
+    val offsetState = remember { mutableStateOf(Offset.Zero) }
+
+    val maxOffsetPx = with(density) { maxOffsetDp.dp.toPx() }
+
+    DisposableEffect(sensorManager) {
+        val sensor = sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
+        if (sensor != null) {
+            val listener = object : SensorEventListener {
+                override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+                override fun onSensorChanged(event: SensorEvent) {
+                    val rotationMatrix = FloatArray(9)
+                    SensorManager.getRotationMatrixFromVector(rotationMatrix, event.values)
+                    val orientations = FloatArray(3)
+                    SensorManager.getOrientation(rotationMatrix, orientations)
+                    val pitch = orientations[1]
+                    val roll = orientations[2]
+
+                    val x = (-roll / (PI / 2)).toFloat().coerceIn(-1f, 1f) * maxOffsetPx
+                    val y = (-pitch / (PI / 2)).toFloat().coerceIn(-1f, 1f) * maxOffsetPx
+                    offsetState.value = Offset(x, y)
+                }
+            }
+            sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_GAME)
+            onDispose { sensorManager.unregisterListener(listener) }
+        } else {
+            onDispose { }
+        }
+    }
+    return offsetState
+}


### PR DESCRIPTION
## Summary
- add `rememberParallaxOffset` to read rotation vector sensor
- offset `AnimatedBackground` with parallax motion

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_688307ec3d1c8327b47cdaa14c68404d