### PR TITLE
Add per-game customization overlay

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -40,6 +40,11 @@ import androidx.core.graphics.drawable.toBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.unit.Density
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.indication
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.ripple
+import androidx.compose.ui.input.pointer.pointerInput
 import com.retrobreeze.ribbonlauncher.model.GameEntry
 import com.retrobreeze.ribbonlauncher.ArrowDirection
 import com.retrobreeze.ribbonlauncher.CarouselArrow
@@ -80,6 +85,7 @@ fun GameCarousel(
     showLabels: Boolean = true,
     showEditButton: Boolean = true,
     onLaunch: (GameEntry) -> Unit,
+    onLongPress: (GameEntry) -> Unit,
     onEdit: () -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -252,6 +258,7 @@ fun GameCarousel(
                         }
                     } else {
                         val game = games[page]
+                        val interaction = remember { MutableInteractionSource() }
                         val gameModifier = Modifier
                             .height(size + (size * 0.25f))
                             .width(size)
@@ -259,14 +266,16 @@ fun GameCarousel(
                                 scaleX = scale
                                 scaleY = scale
                             }
-                            .clickable {
-                                if (isSelected) {
-                                    onLaunch(game)
-                                } else {
-                                    coroutineScope.launch {
-                                        pagerState.animateScrollToPage(page)
+                            .indication(interaction, ripple())
+                            .pointerInput(isSelected) {
+                                detectTapGestures(
+                                    onTap = {
+                                        if (isSelected) onLaunch(game) else coroutineScope.launch { pagerState.animateScrollToPage(page) }
+                                    },
+                                    onLongPress = {
+                                        if (isSelected) onLongPress(game)
                                     }
-                                }
+                                )
                             }
 
                         Box(

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameInfoOverlay.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameInfoOverlay.kt
@@ -70,11 +70,25 @@ fun GameInfoOverlay(
     var editingTitle by remember { mutableStateOf(false) }
     val context = LocalContext.current
 
+    var tempIconUri by remember { mutableStateOf(customization?.iconUri) }
+    var tempWallpaperUri by remember { mutableStateOf(customization?.wallpaperUri) }
+
+    LaunchedEffect(game.packageName) {
+        tempIconUri = customization?.iconUri
+        tempWallpaperUri = customization?.wallpaperUri
+    }
+
     val iconPicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-        uri?.let { onIconChange(it.toString()) }
+        uri?.let {
+            tempIconUri = it.toString()
+            onIconChange(it.toString())
+        }
     }
     val wallpaperPicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-        uri?.let { onWallpaperChange(it.toString()) }
+        uri?.let {
+            tempWallpaperUri = it.toString()
+            onWallpaperChange(it.toString())
+        }
     }
 
     Dialog(
@@ -175,8 +189,9 @@ fun GameInfoOverlay(
                                 style = MaterialTheme.typography.labelLarge
                             )
                             Box(modifier = Modifier.size(120.dp)) {
+                                val iconSource = tempIconUri ?: customization?.iconUri
                                 Image(
-                                    painter = rememberAsyncImagePainter(customization?.iconUri ?: game.icon),
+                                    painter = rememberAsyncImagePainter(iconSource ?: game.icon),
                                     contentDescription = null,
                                     modifier = Modifier.fillMaxSize()
                                 )
@@ -189,7 +204,10 @@ fun GameInfoOverlay(
                                     Text("Change")
                                 }
                                 Spacer(Modifier.width(8.dp))
-                                IconButton(onClick = { onIconChange(null) }) {
+                                IconButton(onClick = {
+                                    tempIconUri = null
+                                    onIconChange(null)
+                                }) {
                                     Icon(Icons.Default.Refresh, contentDescription = "Reset")
                                 }
                             }
@@ -208,9 +226,10 @@ fun GameInfoOverlay(
                                     .fillMaxWidth()
                                     .height(120.dp)
                             ) {
-                                if (customization?.wallpaperUri != null) {
+                                val wallpaperSource = tempWallpaperUri ?: customization?.wallpaperUri
+                                if (wallpaperSource != null) {
                                     Image(
-                                        painter = rememberAsyncImagePainter(customization.wallpaperUri!!),
+                                        painter = rememberAsyncImagePainter(wallpaperSource),
                                         contentDescription = null,
                                         modifier = Modifier
                                             .fillMaxSize()
@@ -234,7 +253,10 @@ fun GameInfoOverlay(
                                     Text("Change")
                                 }
                                 Spacer(Modifier.width(8.dp))
-                                IconButton(onClick = { onWallpaperChange(null) }) {
+                                IconButton(onClick = {
+                                    tempWallpaperUri = null
+                                    onWallpaperChange(null)
+                                }) {
                                     Icon(Icons.Default.Refresh, contentDescription = "Reset")
                                 }
                             }
@@ -254,6 +276,13 @@ fun GameInfoOverlay(
                             contentDescription = "Google Play",
                             tint = MaterialTheme.colorScheme.onSurface
                         )
+                    }
+                    Spacer(Modifier.height(16.dp))
+                    Button(
+                        onClick = onDismiss,
+                        modifier = Modifier.align(Alignment.CenterHorizontally)
+                    ) {
+                        Text("OK")
                     }
                 }
             }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameInfoOverlay.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameInfoOverlay.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.Button
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -169,6 +170,10 @@ fun GameInfoOverlay(
                             modifier = Modifier.weight(1f),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
+                            Text(
+                                text = "Icon",
+                                style = MaterialTheme.typography.labelLarge
+                            )
                             Box(modifier = Modifier.size(120.dp)) {
                                 Image(
                                     painter = rememberAsyncImagePainter(customization?.iconUri ?: game.icon),
@@ -176,15 +181,16 @@ fun GameInfoOverlay(
                                     modifier = Modifier.fillMaxSize()
                                 )
                             }
+                            Spacer(Modifier.height(8.dp))
                             Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween
+                                verticalAlignment = Alignment.CenterVertically
                             ) {
-                                IconButton(onClick = { iconPicker.launch("image/*") }) {
-                                    Icon(Icons.Default.Edit, contentDescription = "Edit")
+                                androidx.compose.material3.Button(onClick = { iconPicker.launch("image/*") }) {
+                                    Text("Change")
                                 }
+                                Spacer(Modifier.width(8.dp))
                                 IconButton(onClick = { onIconChange(null) }) {
-                                    Icon(Icons.Default.Refresh, contentDescription = "Revert")
+                                    Icon(Icons.Default.Refresh, contentDescription = "Reset")
                                 }
                             }
                         }
@@ -193,6 +199,10 @@ fun GameInfoOverlay(
                             modifier = Modifier.weight(1f),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
+                            Text(
+                                text = "Wallpaper",
+                                style = MaterialTheme.typography.labelLarge
+                            )
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -216,15 +226,16 @@ fun GameInfoOverlay(
                                     )
                                 }
                             }
+                            Spacer(Modifier.height(8.dp))
                             Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween
+                                verticalAlignment = Alignment.CenterVertically
                             ) {
-                                IconButton(onClick = { wallpaperPicker.launch("image/*") }) {
-                                    Icon(Icons.Default.Edit, contentDescription = "Edit")
+                                androidx.compose.material3.Button(onClick = { wallpaperPicker.launch("image/*") }) {
+                                    Text("Change")
                                 }
+                                Spacer(Modifier.width(8.dp))
                                 IconButton(onClick = { onWallpaperChange(null) }) {
-                                    Icon(Icons.Default.Refresh, contentDescription = "Revert")
+                                    Icon(Icons.Default.Refresh, contentDescription = "Reset")
                                 }
                             }
                         }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameInfoOverlay.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameInfoOverlay.kt
@@ -1,0 +1,162 @@
+package com.retrobreeze.ribbonlauncher
+
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil.compose.rememberAsyncImagePainter
+import com.retrobreeze.ribbonlauncher.model.AppCustomization
+import com.retrobreeze.ribbonlauncher.model.GameEntry
+import kotlin.math.roundToInt
+
+private const val MAX_LABEL_LENGTH = 30
+
+@Composable
+fun GameInfoOverlay(
+    show: Boolean,
+    game: GameEntry?,
+    customization: AppCustomization?,
+    onDismiss: () -> Unit,
+    onLabelChange: (String?) -> Unit,
+    onIconChange: (String?) -> Unit,
+    onWallpaperChange: (String?) -> Unit
+) {
+    if (game == null) return
+
+    var labelState by remember { mutableStateOf(TextFieldValue(customization?.label ?: game.displayName)) }
+    val context = LocalContext.current
+
+    val iconPicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        uri?.let { onIconChange(it.toString()) }
+    }
+    val wallpaperPicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        uri?.let { onWallpaperChange(it.toString()) }
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        var dragOffset by remember { mutableStateOf(0f) }
+        val threshold = with(LocalContext.current.resources.displayMetrics) { 80 * density }
+        AnimatedVisibility(
+            visible = show,
+            enter = slideInVertically(animationSpec = tween(), initialOffsetY = { it }) + fadeIn(),
+            exit = slideOutVertically(animationSpec = tween(), targetOffsetY = { it }) + fadeOut()
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp)
+                    .offset { IntOffset(0, dragOffset.roundToInt()) }
+                    .pointerInput(Unit) {
+                        detectVerticalDragGestures(
+                            onVerticalDrag = { _, delta -> dragOffset = (dragOffset + delta).coerceAtLeast(0f) },
+                            onDragEnd = {
+                                if (dragOffset > threshold) onDismiss()
+                                dragOffset = 0f
+                            }
+                        )
+                    },
+                shape = MaterialTheme.shapes.medium,
+                color = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .padding(16.dp)
+                ) {
+                    Text(text = "${game.displayName}", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(8.dp))
+                    androidx.compose.material3.TextField(
+                        value = labelState,
+                        onValueChange = { value ->
+                            var text = value.text.replace("\n", "")
+                            if (text.length > MAX_LABEL_LENGTH) text = text.take(MAX_LABEL_LENGTH)
+                            labelState = value.copy(text = text)
+                            onLabelChange(labelState.text.takeIf { it != game.displayName })
+                        },
+                        label = { Text("Custom Name") }
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        OutlinedButton(onClick = { iconPicker.launch("image/*") }) { Text("Change Icon") }
+                        Spacer(Modifier.width(8.dp))
+                        OutlinedButton(onClick = { onIconChange(null) }) { Text("Revert") }
+                    }
+                    customization?.iconUri?.let { uri ->
+                        Spacer(Modifier.height(8.dp))
+                        Image(
+                            painter = rememberAsyncImagePainter(uri),
+                            contentDescription = null,
+                            modifier = Modifier.size(64.dp)
+                        )
+                    }
+                    Spacer(Modifier.height(8.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        OutlinedButton(onClick = { wallpaperPicker.launch("image/*") }) { Text("Change Wallpaper") }
+                        Spacer(Modifier.width(8.dp))
+                        OutlinedButton(onClick = { onWallpaperChange(null) }) { Text("Revert") }
+                    }
+                    customization?.wallpaperUri?.let { uri ->
+                        Spacer(Modifier.height(8.dp))
+                        Image(
+                            painter = rememberAsyncImagePainter(uri),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(120.dp)
+                                .clip(RectangleShape)
+                        )
+                    }
+                    Spacer(Modifier.height(8.dp))
+                    Text("Package: ${game.packageName}")
+                    Spacer(Modifier.height(8.dp))
+                    Button(onClick = {
+                        val uri = Uri.parse("https://play.google.com/store/apps/details?id=${game.packageName}")
+                        context.startActivity(Intent(Intent.ACTION_VIEW, uri))
+                    }) { Text("Play Store") }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameInfoOverlay.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameInfoOverlay.kt
@@ -21,11 +21,9 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Photo
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -41,6 +39,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -158,17 +157,24 @@ fun GameInfoOverlay(
                             modifier = Modifier.weight(1f),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
-                            Image(
-                                painter = rememberAsyncImagePainter(customization?.iconUri ?: game.icon),
-                                contentDescription = null,
-                                modifier = Modifier.size(96.dp)
-                            )
-                            Spacer(Modifier.height(8.dp))
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                OutlinedButton(onClick = { iconPicker.launch("image/*") }) { Text("Edit") }
-                                IconButton(onClick = { onIconChange(null) }) {
-                                    Icon(Icons.Default.Refresh, contentDescription = "Revert")
+                            Box(modifier = Modifier.size(96.dp)) {
+                                Image(
+                                    painter = rememberAsyncImagePainter(customization?.iconUri ?: game.icon),
+                                    contentDescription = null,
+                                    modifier = Modifier.fillMaxSize()
+                                )
+                                IconButton(
+                                    onClick = { iconPicker.launch("image/*") },
+                                    modifier = Modifier.align(Alignment.BottomEnd)
+                                ) {
+                                    Icon(Icons.Default.Edit, contentDescription = "Edit")
                                 }
+                            }
+                            IconButton(
+                                onClick = { onIconChange(null) },
+                                modifier = Modifier.align(Alignment.CenterHorizontally)
+                            ) {
+                                Icon(Icons.Default.Refresh, contentDescription = "Revert")
                             }
                         }
 
@@ -176,41 +182,57 @@ fun GameInfoOverlay(
                             modifier = Modifier.weight(1f),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
-                            if (customization?.wallpaperUri != null) {
-                                Image(
-                                    painter = rememberAsyncImagePainter(customization.wallpaperUri!!),
-                                    contentDescription = null,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .height(120.dp)
-                                        .clip(RectangleShape)
-                                )
-                            } else {
-                                Icon(
-                                    Icons.Default.Photo,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(120.dp)
-                                )
-                            }
-                            Spacer(Modifier.height(8.dp))
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                OutlinedButton(onClick = { wallpaperPicker.launch("image/*") }) { Text("Edit") }
-                                IconButton(onClick = { onWallpaperChange(null) }) {
-                                    Icon(Icons.Default.Refresh, contentDescription = "Revert")
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(120.dp)
+                            ) {
+                                if (customization?.wallpaperUri != null) {
+                                    Image(
+                                        painter = rememberAsyncImagePainter(customization.wallpaperUri!!),
+                                        contentDescription = null,
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .clip(RectangleShape)
+                                    )
+                                } else {
+                                    Icon(
+                                        Icons.Default.Photo,
+                                        contentDescription = null,
+                                        modifier = Modifier
+                                            .size(120.dp)
+                                            .align(Alignment.Center)
+                                    )
                                 }
+                                IconButton(
+                                    onClick = { wallpaperPicker.launch("image/*") },
+                                    modifier = Modifier.align(Alignment.BottomEnd)
+                                ) {
+                                    Icon(Icons.Default.Edit, contentDescription = "Edit")
+                                }
+                            }
+                            IconButton(
+                                onClick = { onWallpaperChange(null) },
+                                modifier = Modifier.align(Alignment.CenterHorizontally)
+                            ) {
+                                Icon(Icons.Default.Refresh, contentDescription = "Revert")
                             }
                         }
                     }
 
                     Spacer(Modifier.height(16.dp))
-                    Button(
+                    IconButton(
                         onClick = {
                             val uri = Uri.parse("https://play.google.com/store/apps/details?id=${game.packageName}")
                             context.startActivity(Intent(Intent.ACTION_VIEW, uri))
                         },
                         modifier = Modifier.align(Alignment.CenterHorizontally)
                     ) {
-                        Text("Google Play")
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_google_play),
+                            contentDescription = "Google Play",
+                            tint = MaterialTheme.colorScheme.onSurface
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameInfoOverlay.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameInfoOverlay.kt
@@ -77,33 +77,34 @@ fun GameInfoOverlay(
 
     Dialog(
         onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false)
+        properties = DialogProperties(usePlatformDefaultWidth = false, dismissOnClickOutside = true)
     ) {
-        var dragOffset by remember { mutableStateOf(0f) }
-        val threshold = with(LocalContext.current.resources.displayMetrics) { 80 * density }
-        AnimatedVisibility(
-            visible = show,
-            enter = slideInVertically(animationSpec = tween(), initialOffsetY = { it }) + fadeIn(),
-            exit = slideOutVertically(animationSpec = tween(), targetOffsetY = { it }) + fadeOut()
-        ) {
-            Surface(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(24.dp)
-                    .offset { IntOffset(0, dragOffset.roundToInt()) }
-                    .pointerInput(Unit) {
-                        detectVerticalDragGestures(
-                            onVerticalDrag = { _, delta -> dragOffset = (dragOffset + delta).coerceAtLeast(0f) },
-                            onDragEnd = {
-                                if (dragOffset > threshold) onDismiss()
-                                dragOffset = 0f
-                            }
-                        )
-                    },
-                shape = MaterialTheme.shapes.medium,
-                color = MaterialTheme.colorScheme.surface,
-                contentColor = MaterialTheme.colorScheme.onSurface
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
+            var dragOffset by remember { mutableStateOf(0f) }
+            val threshold = with(LocalContext.current.resources.displayMetrics) { 80 * density }
+            AnimatedVisibility(
+                visible = show,
+                enter = slideInVertically(animationSpec = tween(), initialOffsetY = { it }) + fadeIn(),
+                exit = slideOutVertically(animationSpec = tween(), targetOffsetY = { it }) + fadeOut()
             ) {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth(0.5f)
+                        .padding(horizontal = 24.dp, vertical = 24.dp)
+                        .offset { IntOffset(0, dragOffset.roundToInt()) }
+                        .pointerInput(Unit) {
+                            detectVerticalDragGestures(
+                                onVerticalDrag = { _, delta -> dragOffset = (dragOffset + delta).coerceAtLeast(0f) },
+                                onDragEnd = {
+                                    if (dragOffset > threshold) onDismiss()
+                                    dragOffset = 0f
+                                }
+                            )
+                        },
+                    shape = MaterialTheme.shapes.medium,
+                    color = MaterialTheme.colorScheme.surface,
+                    contentColor = MaterialTheme.colorScheme.onSurface
+                ) {
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -215,4 +216,6 @@ fun GameInfoOverlay(
             }
         }
     }
+}
+
 }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameInfoOverlay.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameInfoOverlay.kt
@@ -12,6 +12,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -42,6 +43,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import coil.compose.rememberAsyncImagePainter
@@ -84,7 +86,8 @@ fun GameInfoOverlay(
             AnimatedVisibility(
                 visible = show,
                 enter = slideInVertically(animationSpec = tween(), initialOffsetY = { it }) + fadeIn(),
-                exit = slideOutVertically(animationSpec = tween(), targetOffsetY = { it }) + fadeOut()
+                exit = slideOutVertically(animationSpec = tween(), targetOffsetY = { it }) + fadeOut(),
+                modifier = Modifier.align(Alignment.BottomCenter)
             ) {
                 Surface(
                     modifier = Modifier
@@ -110,7 +113,11 @@ fun GameInfoOverlay(
                         .verticalScroll(rememberScrollState())
                         .padding(16.dp)
                 ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
                         if (editingTitle) {
                             androidx.compose.material3.TextField(
                                 value = titleText,
@@ -123,7 +130,7 @@ fun GameInfoOverlay(
                                 },
                                 modifier = Modifier.weight(1f),
                                 singleLine = true,
-                                textStyle = MaterialTheme.typography.titleLarge,
+                                textStyle = MaterialTheme.typography.titleLarge.copy(textAlign = TextAlign.Center),
                                 trailingIcon = {
                                     IconButton(onClick = { editingTitle = false }) {
                                         Icon(Icons.Default.Check, contentDescription = "Done")
@@ -134,7 +141,10 @@ fun GameInfoOverlay(
                             Text(
                                 text = titleText,
                                 style = MaterialTheme.typography.titleLarge,
-                                modifier = Modifier.weight(1f)
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .clickable { editingTitle = true },
+                                textAlign = TextAlign.Center
                             )
                             IconButton(onClick = { editingTitle = true }) {
                                 Icon(Icons.Default.Edit, contentDescription = "Edit")
@@ -145,7 +155,9 @@ fun GameInfoOverlay(
                     Text(
                         text = game.packageName,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.align(Alignment.CenterHorizontally),
+                        textAlign = TextAlign.Center
                     )
                     Spacer(Modifier.height(16.dp))
 
@@ -157,24 +169,23 @@ fun GameInfoOverlay(
                             modifier = Modifier.weight(1f),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
-                            Box(modifier = Modifier.size(96.dp)) {
+                            Box(modifier = Modifier.size(120.dp)) {
                                 Image(
                                     painter = rememberAsyncImagePainter(customization?.iconUri ?: game.icon),
                                     contentDescription = null,
                                     modifier = Modifier.fillMaxSize()
                                 )
-                                IconButton(
-                                    onClick = { iconPicker.launch("image/*") },
-                                    modifier = Modifier.align(Alignment.BottomEnd)
-                                ) {
+                            }
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                IconButton(onClick = { iconPicker.launch("image/*") }) {
                                     Icon(Icons.Default.Edit, contentDescription = "Edit")
                                 }
-                            }
-                            IconButton(
-                                onClick = { onIconChange(null) },
-                                modifier = Modifier.align(Alignment.CenterHorizontally)
-                            ) {
-                                Icon(Icons.Default.Refresh, contentDescription = "Revert")
+                                IconButton(onClick = { onIconChange(null) }) {
+                                    Icon(Icons.Default.Refresh, contentDescription = "Revert")
+                                }
                             }
                         }
 
@@ -204,18 +215,17 @@ fun GameInfoOverlay(
                                             .align(Alignment.Center)
                                     )
                                 }
-                                IconButton(
-                                    onClick = { wallpaperPicker.launch("image/*") },
-                                    modifier = Modifier.align(Alignment.BottomEnd)
-                                ) {
+                            }
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                IconButton(onClick = { wallpaperPicker.launch("image/*") }) {
                                     Icon(Icons.Default.Edit, contentDescription = "Edit")
                                 }
-                            }
-                            IconButton(
-                                onClick = { onWallpaperChange(null) },
-                                modifier = Modifier.align(Alignment.CenterHorizontally)
-                            ) {
-                                Icon(Icons.Default.Refresh, contentDescription = "Revert")
+                                IconButton(onClick = { onWallpaperChange(null) }) {
+                                    Icon(Icons.Default.Refresh, contentDescription = "Revert")
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -151,7 +151,10 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                 show = showInfoOverlay,
                 game = overlayGame,
                 customization = viewModel.getCustomization(overlayGame?.packageName),
-                onDismiss = { showInfoOverlay = false },
+                onDismiss = {
+                    showInfoOverlay = false
+                    overlayGame = null
+                },
                 onLabelChange = { text -> overlayGame?.packageName?.let { viewModel.updateCustomLabel(it, text) } },
                 onIconChange = { uri -> overlayGame?.packageName?.let { viewModel.updateCustomIcon(it, uri) } },
                 onWallpaperChange = { uri -> overlayGame?.packageName?.let { viewModel.updateCustomWallpaper(it, uri) } }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/model/AppCustomization.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/model/AppCustomization.kt
@@ -1,0 +1,10 @@
+package com.retrobreeze.ribbonlauncher.model
+
+/**
+ * Stores per-app customization such as custom label, icon and wallpaper URIs.
+ */
+data class AppCustomization(
+    var label: String? = null,
+    var iconUri: String? = null,
+    var wallpaperUri: String? = null
+)

--- a/app/src/main/res/drawable/ic_google_play.xml
+++ b/app/src/main/res/drawable/ic_google_play.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M3,20.5V3.5C3,2.91 3.34,2.39 3.84,2.15L13.69,12L3.84,21.85C3.34,21.6 3,21.09 3,20.5M16.81,15.12L6.05,21.34L14.54,12.85L16.81,15.12M20.16,10.81C20.5,11.08 20.75,11.5 20.75,12C20.75,12.5 20.53,12.9 20.18,13.18L17.89,14.5L15.39,12L17.89,9.5L20.16,10.81M6.05,2.66L16.81,8.88L14.54,11.15L6.05,2.66Z" />
+</vector>


### PR DESCRIPTION
## Summary
- implement `GameInfoOverlay` for per-game icon, name, and wallpaper
- support custom icons and wallpapers via `AppCustomization`
- show custom wallpaper and icon in launcher
- enable long-press on game icons to open overlay
- update animated background to crossfade to per-game wallpaper

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68830e4c71e48327bf659929521f6e30