### PR TITLE
Add pinned apps support

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -82,8 +82,10 @@ fun GameCarousel(
     showLabels: Boolean = true,
     showEditButton: Boolean = true,
     settingsExpanded: Boolean = false,
+    pinnedCount: Int = 0,
     onLaunch: (GameEntry) -> Unit,
-    onEdit: () -> Unit
+    onEdit: () -> Unit,
+    onPinToggle: (GameEntry) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val baseItemSpacing = 12.dp
@@ -286,6 +288,15 @@ fun GameCarousel(
                             // menu moved below label when settings are open
                         }
                     }
+                    if (pinnedCount > 0 && page == pinnedCount - 1) {
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.CenterEnd)
+                                .fillMaxHeight()
+                                .width(1.dp)
+                                .background(Color.White.copy(alpha = 0.3f))
+                        )
+                    }
                 }
             }
         }
@@ -348,7 +359,7 @@ fun GameCarousel(
                 AppEditMenu(
                     visible = true,
                     iconSize = 24.dp,
-                    onPinToggle = {},
+                    onPinToggle = { onPinToggle(games[pagerState.currentPage]) },
                     onCustomTitle = {},
                     onCustomIcon = {},
                     onCustomWallpaper = {},

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -102,6 +102,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     showLabels = viewModel.showLabels,
                     showEditButton = !viewModel.settingsLocked,
                     settingsExpanded = settingsMenuExpanded,
+                    pinnedCount = viewModel.visiblePinnedCount,
                     onLaunch = { game ->
                         val intent = context.packageManager.getLaunchIntentForPackage(game.packageName)
                         if (intent != null) {
@@ -112,7 +113,8 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                         }
                         viewModel.recordLaunch(game)
                     },
-                    onEdit = { showEditDialog = true }
+                    onEdit = { showEditDialog = true },
+                    onPinToggle = { viewModel.togglePin(it.packageName) }
                 )
             }
             AppDrawerOverlay(


### PR DESCRIPTION
## Summary
- add pinned apps list to LauncherViewModel
- keep pinned apps at the start of the ribbon regardless of sort
- allow pinning/unpinning apps from the edit menu
- show divider after last pinned app

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6883c7875e5c83278a0387ea201166df