### PR TITLE
Add custom icon selection

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/AppEditMenu.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/AppEditMenu.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.CheckBoxOutlineBlank
 import androidx.compose.material.icons.filled.Photo
 import androidx.compose.material.icons.filled.Replay
 import androidx.compose.material.icons.filled.PushPin
@@ -66,7 +66,7 @@ fun AppEditMenu(
             )
             Spacer(Modifier.width(spacing))
             Icon(
-                imageVector = Icons.Default.AutoAwesome,
+                imageVector = Icons.Default.CheckBoxOutlineBlank,
                 contentDescription = "Custom Icon",
                 modifier = Modifier
                     .size(iconSize)

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -85,7 +85,8 @@ fun GameCarousel(
     pinnedCount: Int = 0,
     onLaunch: (GameEntry) -> Unit,
     onEdit: () -> Unit,
-    onPinToggle: (GameEntry) -> Unit
+    onPinToggle: (GameEntry) -> Unit,
+    onCustomIcon: (GameEntry) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val baseItemSpacing = 12.dp
@@ -371,7 +372,7 @@ fun GameCarousel(
                     iconSize = 24.dp,
                     onPinToggle = { onPinToggle(games[pagerState.currentPage]) },
                     onCustomTitle = {},
-                    onCustomIcon = {},
+                    onCustomIcon = { onCustomIcon(games[pagerState.currentPage]) },
                     onCustomWallpaper = {},
                     onReset = {}
                 )

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
@@ -317,6 +317,10 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
     fun updateCustomIcon(packageName: String, uri: Uri) {
         val context = getApplication<Application>().applicationContext
         try {
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
             context.contentResolver.openInputStream(uri)?.use { stream ->
                 val drawable = Drawable.createFromStream(stream, uri.toString()) ?: return
                 customIcons[packageName] = drawable

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -79,7 +79,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
     var settingsMenuExpanded by remember { mutableStateOf(false) }
     val pagerState = rememberPagerState(initialPage = 0) { games.size + if (!viewModel.settingsLocked) 1 else 0 }
 
-    val pickIconLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+    val pickIconLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         uri?.let { selectedUri ->
             viewModel.selectedGamePackage?.let { pkg ->
                 viewModel.updateCustomIcon(pkg, selectedUri)
@@ -125,7 +125,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     },
                     onEdit = { showEditDialog = true },
                     onPinToggle = { viewModel.togglePin(it.packageName) },
-                    onCustomIcon = { pickIconLauncher.launch("image/*") }
+                    onCustomIcon = { pickIconLauncher.launch(arrayOf("image/*")) }
                 )
             }
             AppDrawerOverlay(

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -17,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.LaunchedEffect
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -77,6 +79,14 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
     var settingsMenuExpanded by remember { mutableStateOf(false) }
     val pagerState = rememberPagerState(initialPage = 0) { games.size + if (!viewModel.settingsLocked) 1 else 0 }
 
+    val pickIconLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        uri?.let { selectedUri ->
+            viewModel.selectedGamePackage?.let { pkg ->
+                viewModel.updateCustomIcon(pkg, selectedUri)
+            }
+        }
+    }
+
     LaunchedEffect(pagerState.currentPage, games) {
         val pkg = games.getOrNull(pagerState.currentPage)?.packageName
         viewModel.setSelectedGame(pkg)
@@ -114,7 +124,8 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                         viewModel.recordLaunch(game)
                     },
                     onEdit = { showEditDialog = true },
-                    onPinToggle = { viewModel.togglePin(it.packageName) }
+                    onPinToggle = { viewModel.togglePin(it.packageName) },
+                    onCustomIcon = { pickIconLauncher.launch("image/*") }
                 )
             }
             AppDrawerOverlay(


### PR DESCRIPTION
## Summary
- swap sparkles icon for a square outline in `AppEditMenu`
- allow picking custom icons from `LauncherScreen`
- support saving custom icons in `LauncherViewModel`
- apply custom icons to game lists

## Testing
- `./gradlew assembleDebug --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6883e8202940832795b91e67a97b9363