### PR TITLE
Support custom per-app wallpapers

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -85,7 +85,8 @@ fun GameCarousel(
     pinnedCount: Int = 0,
     onLaunch: (GameEntry) -> Unit,
     onEdit: () -> Unit,
-    onPinToggle: (GameEntry) -> Unit
+    onPinToggle: (GameEntry) -> Unit,
+    onCustomWallpaper: (GameEntry) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val baseItemSpacing = 12.dp
@@ -372,7 +373,7 @@ fun GameCarousel(
                     onPinToggle = { onPinToggle(games[pagerState.currentPage]) },
                     onCustomTitle = {},
                     onCustomIcon = {},
-                    onCustomWallpaper = {},
+                    onCustomWallpaper = { onCustomWallpaper(games[pagerState.currentPage]) },
                     onReset = {}
                 )
             }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -73,6 +73,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
     var showSettingsPage by remember { mutableStateOf(false) }
     var showEditDialog by remember { mutableStateOf(false) }
     var showWallpaperDialog by remember { mutableStateOf(false) }
+    var showAppWallpaperDialog by remember { mutableStateOf(false) }
     var showResetDialog by remember { mutableStateOf(false) }
     var settingsMenuExpanded by remember { mutableStateOf(false) }
     val pagerState = rememberPagerState(initialPage = 0) { games.size + if (!viewModel.settingsLocked) 1 else 0 }
@@ -82,10 +83,12 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
         viewModel.setSelectedGame(pkg)
     }
 
+    val activeTheme = viewModel.getAppWallpaper(viewModel.selectedGamePackage) ?: viewModel.wallpaperTheme
+
     Surface(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.fillMaxSize()) {
             AnimatedBackground(
-                theme = viewModel.wallpaperTheme,
+                theme = activeTheme,
                 modifier = Modifier.fillMaxSize()
             )
             Box(
@@ -114,7 +117,8 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                         viewModel.recordLaunch(game)
                     },
                     onEdit = { showEditDialog = true },
-                    onPinToggle = { viewModel.togglePin(it.packageName) }
+                    onPinToggle = { viewModel.togglePin(it.packageName) },
+                    onCustomWallpaper = { showAppWallpaperDialog = true }
                 )
             }
             AppDrawerOverlay(
@@ -136,6 +140,14 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                 current = viewModel.wallpaperTheme,
                 onSelect = { viewModel.updateWallpaperTheme(it) },
                 onDismiss = { showWallpaperDialog = false }
+            )
+            WallpaperThemeDialog(
+                show = showAppWallpaperDialog,
+                current = viewModel.getAppWallpaper(viewModel.selectedGamePackage) ?: viewModel.wallpaperTheme,
+                onSelect = { theme ->
+                    viewModel.selectedGamePackage?.let { viewModel.updateAppWallpaper(it, theme) }
+                },
+                onDismiss = { showAppWallpaperDialog = false }
             )
             ResetConfirmationDialog(
                 show = showResetDialog,


### PR DESCRIPTION
## Summary
- store custom wallpapers per app and persist them
- expose wallpaper update API in `LauncherViewModel`
- show selected app wallpaper while scrolling
- open wallpaper picker from the app menu

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_6883f2ef17b88327a6d1a23d8bccfcd3