### PR TITLE
Implement inline game title editing

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -125,7 +125,10 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     },
                     onEdit = { showEditDialog = true },
                     onPinToggle = { viewModel.togglePin(it.packageName) },
-                    onCustomIcon = { pickIconLauncher.launch(arrayOf("image/*")) }
+                    onCustomIcon = { pickIconLauncher.launch(arrayOf("image/*")) },
+                    onTitleChange = { game, title ->
+                        viewModel.updateCustomTitle(game.packageName, title)
+                    }
                 )
             }
             AppDrawerOverlay(


### PR DESCRIPTION
## Summary
- add custom title storage in view model
- apply saved titles when loading games/apps
- allow editing game titles from carousel menu
- add callbacks in `GameCarousel` to persist title changes

## Testing
- `./gradlew assembleDebug`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6884798425c8832784e195c4b2d5078e