### PR TITLE
Add per-app wallpaper support

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -100,6 +100,7 @@ fun GameCarousel(
     onEdit: () -> Unit,
     onPinToggle: (GameEntry) -> Unit,
     onCustomIcon: (GameEntry) -> Unit,
+    onCustomWallpaper: (GameEntry) -> Unit,
     onTitleChange: (GameEntry, String) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -436,7 +437,7 @@ fun GameCarousel(
                         editingTitle = true
                     },
                     onCustomIcon = { onCustomIcon(games[pagerState.currentPage]) },
-                    onCustomWallpaper = {},
+                    onCustomWallpaper = { onCustomWallpaper(games[pagerState.currentPage]) },
                     onReset = {}
                 )
             }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -37,7 +37,7 @@ import com.retrobreeze.ribbonlauncher.SettingsPage
 import com.retrobreeze.ribbonlauncher.EditAppsDialog
 import com.retrobreeze.ribbonlauncher.WallpaperThemeDialog
 import com.retrobreeze.ribbonlauncher.ResetConfirmationDialog
-import com.retrobreeze.ribbonlauncher.ui.background.AnimatedBackground
+import com.retrobreeze.ribbonlauncher.ui.background.Wallpaper
 import com.retrobreeze.ribbonlauncher.ui.theme.RibbonLauncherTheme
 
 class MainActivity : ComponentActivity() {
@@ -87,6 +87,14 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
         }
     }
 
+    val pickWallpaperLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        uri?.let { selectedUri ->
+            viewModel.selectedGamePackage?.let { pkg ->
+                viewModel.updateCustomWallpaper(pkg, selectedUri)
+            }
+        }
+    }
+
     LaunchedEffect(pagerState.currentPage, games) {
         val pkg = games.getOrNull(pagerState.currentPage)?.packageName
         viewModel.setSelectedGame(pkg)
@@ -94,8 +102,9 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
 
     Surface(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.fillMaxSize()) {
-            AnimatedBackground(
+            Wallpaper(
                 theme = viewModel.wallpaperTheme,
+                imageUri = viewModel.getCustomWallpaper(viewModel.selectedGamePackage),
                 modifier = Modifier.fillMaxSize()
             )
             Box(
@@ -126,6 +135,7 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     onEdit = { showEditDialog = true },
                     onPinToggle = { viewModel.togglePin(it.packageName) },
                     onCustomIcon = { pickIconLauncher.launch(arrayOf("image/*")) },
+                    onCustomWallpaper = { pickWallpaperLauncher.launch(arrayOf("image/*")) },
                     onTitleChange = { game, title ->
                         viewModel.updateCustomTitle(game.packageName, title)
                     }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/ui/background/Wallpaper.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/ui/background/Wallpaper.kt
@@ -1,0 +1,35 @@
+package com.retrobreeze.ribbonlauncher.ui.background
+
+import android.net.Uri
+import androidx.compose.animation.Crossfade
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+
+@Composable
+fun Wallpaper(
+    theme: WallpaperTheme,
+    imageUri: Uri?,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val key = imageUri?.toString() ?: theme.name
+    Crossfade(targetState = key, label = "wallpaperCrossfade") { state ->
+        if (imageUri != null && state == imageUri.toString()) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(imageUri)
+                    .crossfade(false)
+                    .build(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = modifier
+            )
+        } else {
+            AnimatedBackground(theme = theme, modifier = modifier)
+        }
+    }
+}

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/ui/background/Wallpaper.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/ui/background/Wallpaper.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import coil.compose.AsyncImage
+import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 
 @Composable
@@ -16,16 +16,16 @@ fun Wallpaper(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val key = imageUri?.toString() ?: theme.name
-    Crossfade(targetState = key, label = "wallpaperCrossfade") { state ->
-        if (imageUri != null && state == imageUri.toString()) {
-            AsyncImage(
-                model = ImageRequest.Builder(context)
-                    .data(imageUri)
-                    .crossfade(false)
-                    .build(),
+    val request = imageUri?.let {
+        ImageRequest.Builder(context).data(it).crossfade(true).build()
+    }
+    Crossfade(targetState = request, label = "wallpaperCrossfade") { target ->
+        if (target != null) {
+            SubcomposeAsyncImage(
+                model = target,
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
+                loading = { AnimatedBackground(theme = theme, modifier = modifier) },
                 modifier = modifier
             )
         } else {


### PR DESCRIPTION
## Summary
- persist custom wallpapers for each app in `LauncherViewModel`
- allow picking wallpapers from GameCarousel menu
- crossfade between wallpapers and theme in new `Wallpaper` composable

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_688494b2e5488327b09b7ee4dfd82fa9