### PR TITLE
Implement per-app reset option

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/AppEditMenu.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/AppEditMenu.kt
@@ -81,6 +81,12 @@ fun AppEditMenu(
                     .clickable { onCustomWallpaper() }
             )
             Spacer(Modifier.width(spacing))
+            Divider(
+                modifier = Modifier
+                    .height(iconSize)
+                    .width(1.dp)
+            )
+            Spacer(Modifier.width(spacing))
             Icon(
                 imageVector = Icons.Default.Replay,
                 contentDescription = "Reset All",

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -101,7 +101,8 @@ fun GameCarousel(
     onPinToggle: (GameEntry) -> Unit,
     onCustomIcon: (GameEntry) -> Unit,
     onCustomWallpaper: (GameEntry) -> Unit,
-    onTitleChange: (GameEntry, String) -> Unit
+    onTitleChange: (GameEntry, String) -> Unit,
+    onReset: (GameEntry) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val baseItemSpacing = 12.dp
@@ -438,7 +439,7 @@ fun GameCarousel(
                     },
                     onCustomIcon = { onCustomIcon(games[pagerState.currentPage]) },
                     onCustomWallpaper = { onCustomWallpaper(games[pagerState.currentPage]) },
-                    onReset = {}
+                    onReset = { onReset(games[pagerState.currentPage]) }
                 )
             }
         }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/LauncherViewModel.kt
@@ -395,6 +395,35 @@ class LauncherViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
+    private fun getDefaultIcon(pkg: String): Drawable {
+        val context = getApplication<Application>().applicationContext
+        return try {
+            context.packageManager.getApplicationIcon(pkg)
+        } catch (_: Exception) {
+            context.getDrawable(android.R.drawable.sym_def_app_icon)!!
+        }
+    }
+
+    fun resetAppCustomizations(packageName: String) {
+        customIcons.remove(packageName)
+        customTitles.remove(packageName)
+        customWallpapers.remove(packageName)
+        prefs.edit()
+            .remove(KEY_CUSTOM_ICON_PREFIX + packageName)
+            .remove(KEY_CUSTOM_TITLE_PREFIX + packageName)
+            .remove(KEY_CUSTOM_WALLPAPER_PREFIX + packageName)
+            .apply()
+        val defaultLabel = getDefaultLabel(packageName)
+        val defaultIcon = getDefaultIcon(packageName)
+        allGames = allGames.map {
+            if (it.packageName == packageName) it.copy(displayName = defaultLabel, icon = defaultIcon) else it
+        }
+        apps = apps.map {
+            if (it.packageName == packageName) it.copy(displayName = defaultLabel, icon = defaultIcon) else it
+        }
+        sortGames()
+    }
+
     private fun applyCustomIcons() {
         if (customIcons.isEmpty()) return
         allGames = allGames.map { entry ->

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/MainActivity.kt
@@ -37,8 +37,10 @@ import com.retrobreeze.ribbonlauncher.SettingsPage
 import com.retrobreeze.ribbonlauncher.EditAppsDialog
 import com.retrobreeze.ribbonlauncher.WallpaperThemeDialog
 import com.retrobreeze.ribbonlauncher.ResetConfirmationDialog
+import com.retrobreeze.ribbonlauncher.ResetAppDialog
 import com.retrobreeze.ribbonlauncher.ui.background.Wallpaper
 import com.retrobreeze.ribbonlauncher.ui.theme.RibbonLauncherTheme
+import com.retrobreeze.ribbonlauncher.model.GameEntry
 
 class MainActivity : ComponentActivity() {
     private val launcherViewModel: LauncherViewModel by viewModels()
@@ -76,6 +78,8 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
     var showEditDialog by remember { mutableStateOf(false) }
     var showWallpaperDialog by remember { mutableStateOf(false) }
     var showResetDialog by remember { mutableStateOf(false) }
+    var showAppResetDialog by remember { mutableStateOf(false) }
+    var resetTarget by remember { mutableStateOf<GameEntry?>(null) }
     var settingsMenuExpanded by remember { mutableStateOf(false) }
     val pagerState = rememberPagerState(initialPage = 0) { games.size + if (!viewModel.settingsLocked) 1 else 0 }
 
@@ -138,6 +142,10 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                     onCustomWallpaper = { pickWallpaperLauncher.launch(arrayOf("image/*")) },
                     onTitleChange = { game, title ->
                         viewModel.updateCustomTitle(game.packageName, title)
+                    },
+                    onReset = { game ->
+                        resetTarget = game
+                        showAppResetDialog = true
                     }
                 )
             }
@@ -160,6 +168,15 @@ fun LauncherScreen(viewModel: LauncherViewModel = viewModel()) {
                 current = viewModel.wallpaperTheme,
                 onSelect = { viewModel.updateWallpaperTheme(it) },
                 onDismiss = { showWallpaperDialog = false }
+            )
+            ResetAppDialog(
+                show = showAppResetDialog,
+                appName = resetTarget?.displayName ?: "this app",
+                onConfirm = {
+                    resetTarget?.packageName?.let { viewModel.resetAppCustomizations(it) }
+                    showAppResetDialog = false
+                },
+                onDismiss = { showAppResetDialog = false }
             )
             ResetConfirmationDialog(
                 show = showResetDialog,

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/ResetAppDialog.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/ResetAppDialog.kt
@@ -1,0 +1,31 @@
+package com.retrobreeze.ribbonlauncher
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun ResetAppDialog(
+    show: Boolean,
+    appName: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    if (!show) return
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Reset $appName?") },
+        text = { Text("This will remove the custom title, icon and wallpaper for this app.") },
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            OutlinedButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}


### PR DESCRIPTION
## Summary
- add divider before reset option in AppEditMenu
- implement a reset confirmation dialog for individual apps
- handle resetting title, icon and wallpaper to defaults
- hook up reset flow via MainActivity and GameCarousel

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_6884df9e839883278999739b71da777e