### PR TITLE
Fix locked edit menu display

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -426,22 +426,21 @@ fun GameCarousel(
                     }
                 }
             }
-            if (settingsExpanded && showEditButton && pagerState.currentPage < games.size) {
-                Spacer(Modifier.height(8.dp))
-                AppEditMenu(
-                    visible = true,
-                    iconSize = 32.dp,
-                    onPinToggle = { onPinToggle(games[pagerState.currentPage]) },
-                    onCustomTitle = {
-                        val title = games[pagerState.currentPage].displayName
-                        localTitle = TextFieldValue(title)
-                        editingTitle = true
-                    },
-                    onCustomIcon = { onCustomIcon(games[pagerState.currentPage]) },
-                    onCustomWallpaper = { onCustomWallpaper(games[pagerState.currentPage]) },
-                    onReset = { onReset(games[pagerState.currentPage]) }
-                )
-            }
+            val showEditMenu = settingsExpanded && showEditButton && pagerState.currentPage < games.size
+            Spacer(Modifier.height(if (showEditMenu) 8.dp else 0.dp))
+            AppEditMenu(
+                visible = showEditMenu,
+                iconSize = 32.dp,
+                onPinToggle = { onPinToggle(games[pagerState.currentPage]) },
+                onCustomTitle = {
+                    val title = games[pagerState.currentPage].displayName
+                    localTitle = TextFieldValue(title)
+                    editingTitle = true
+                },
+                onCustomIcon = { onCustomIcon(games[pagerState.currentPage]) },
+                onCustomWallpaper = { onCustomWallpaper(games[pagerState.currentPage]) },
+                onReset = { onReset(games[pagerState.currentPage]) }
+            )
         }
     }
 }

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -426,7 +426,7 @@ fun GameCarousel(
                     }
                 }
             }
-            if (settingsExpanded && pagerState.currentPage < games.size) {
+            if (settingsExpanded && showEditButton && pagerState.currentPage < games.size) {
                 Spacer(Modifier.height(8.dp))
                 AppEditMenu(
                     visible = true,


### PR DESCRIPTION
## Summary
- ensure editing menu is hidden when settings are locked

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688516a2bb748327ae6b16a3ee9e52ef