### PR TITLE
Fix label glitch when closing AppEditMenu

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.pager.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -370,7 +371,8 @@ fun GameCarousel(
         Column(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .padding(bottom = 8.dp),
+                .padding(bottom = 8.dp)
+                .animateContentSize(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             if (editingTitle) {


### PR DESCRIPTION
## Summary
- animate the GameCarousel bottom column size so the title label slides into place smoothly

## Testing
- `./gradlew test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_688522da4440832792861c6db78f68f9