### PR TITLE
Fix label glitch when closing AppEditMenu

### DIFF
--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/AppEditMenu.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/AppEditMenu.kt
@@ -2,8 +2,8 @@ package com.retrobreeze.ribbonlauncher
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.clickable
@@ -37,8 +37,8 @@ fun AppEditMenu(
 ) {
     AnimatedVisibility(
         visible = visible,
-        enter = expandVertically(expandFrom = Alignment.Bottom) + fadeIn(),
-        exit = shrinkVertically(shrinkTowards = Alignment.Bottom) + fadeOut(),
+        enter = expandHorizontally(expandFrom = Alignment.Start) + fadeIn(),
+        exit = shrinkHorizontally(shrinkTowards = Alignment.End) + fadeOut(),
         modifier = modifier
     ) {
         val spacing = iconSize * 0.33f
@@ -104,6 +104,7 @@ private fun AppEditMenuPreview() {
     AppEditMenu(
         visible = true,
         iconSize = 32.dp,
+        modifier = Modifier.padding(top = 8.dp),
         onPinToggle = {},
         onCustomTitle = {},
         onCustomIcon = {},

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/AppEditMenu.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/AppEditMenu.kt
@@ -2,8 +2,8 @@ package com.retrobreeze.ribbonlauncher
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.expandHorizontally
-import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.clickable
@@ -37,8 +37,8 @@ fun AppEditMenu(
 ) {
     AnimatedVisibility(
         visible = visible,
-        enter = expandHorizontally() + fadeIn(),
-        exit = shrinkHorizontally() + fadeOut(),
+        enter = expandVertically(expandFrom = Alignment.Bottom) + fadeIn(),
+        exit = shrinkVertically(shrinkTowards = Alignment.Bottom) + fadeOut(),
         modifier = modifier
     ) {
         val spacing = iconSize * 0.33f

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -429,10 +429,10 @@ fun GameCarousel(
                 }
             }
             val showEditMenu = settingsExpanded && showEditButton && pagerState.currentPage < games.size
-            Spacer(Modifier.height(if (showEditMenu) 8.dp else 0.dp))
             AppEditMenu(
                 visible = showEditMenu,
                 iconSize = 32.dp,
+                modifier = Modifier.padding(top = 8.dp),
                 onPinToggle = { onPinToggle(games[pagerState.currentPage]) },
                 onCustomTitle = {
                     val title = games[pagerState.currentPage].displayName

--- a/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
+++ b/app/src/main/java/com/retrobreeze/ribbonlauncher/GameCarousel.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.pager.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -370,7 +371,8 @@ fun GameCarousel(
         Column(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .padding(bottom = 8.dp),
+                .padding(bottom = 8.dp)
+                .animateContentSize(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             if (editingTitle) {


### PR DESCRIPTION
## Summary
- animate the GameCarousel bottom column size so the title label slides into place smoothly

## Testing
- `./gradlew test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_688522da4440832792861c6db78f68f9